### PR TITLE
TOT-3 : [CHORE] 작업환경 별 설정파일 분리 및 암호화

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ env:
   BUCKET_NAME: triportreat-bucket
   CODE_DEPLOY_APP_NAME: triportreat-codedeploy-application
   DEPLOYMENT_GROUP_NAME: triportreat-deploy-group
+  JASYPT_SECRET_KEY: ${{ secrets.JASYPT_SECRET_KEY }}
 
 jobs:
   deploy:
@@ -30,8 +31,8 @@ jobs:
         run: chmod +x ./gradlew
         shell: bash
 
-      - name: Build and Test
-        run: ./gradlew build
+      - name: Build and Test(사용하는 프로파일은 develop, 암호화키는 환경변수로 등록 후 빌드 실행)
+        run: ./gradlew build -Dspring.profiles.active=develop
         shell: bash
 
       - name: Make Zip File

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -25,7 +25,6 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-application.yml
 
 ### NetBeans ###
 /nbproject/private/
@@ -36,3 +35,6 @@ application.yml
 
 ### VS Code ###
 .vscode/
+
+### mac ###
+.DS_Store

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation "com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5"
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/src/main/java/com/triportreat/backend/JasyptConfig.java
+++ b/backend/src/main/java/com/triportreat/backend/JasyptConfig.java
@@ -1,0 +1,34 @@
+package com.triportreat.backend;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JasyptConfig {
+
+    @Value("${spring.jasypt.encryptor.password}")
+    private String encryptKey;
+
+    /**
+     * String encryptor string encryptor.
+     *
+     * @return the string encryptor
+     */
+    @Bean("jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor(){
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword(encryptKey);
+        config.setPoolSize("1");
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setStringOutputType("base64");
+        config.setKeyObtentionIterations("1000");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+}

--- a/backend/src/main/resources/application-common.yml
+++ b/backend/src/main/resources/application-common.yml
@@ -1,0 +1,3 @@
+spring:
+  jasypt:
+    encryptor:

--- a/backend/src/main/resources/application-common.yml
+++ b/backend/src/main/resources/application-common.yml
@@ -1,3 +1,4 @@
 spring:
   jasypt:
     encryptor:
+      password: ${JASYPT_SECRET_KEY}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -13,8 +13,6 @@ spring:
     hibernate:
       ddl-auto: none
 
-    database-platform: org.hibernate.dialect.MySQLDialect
-
     properties:
       hibernate:
         format_sql: true

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -5,9 +5,9 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url:
-    username:
-    password:
+    url: ENC(vBkFtshaUZ/2Dd6BWiDqnkZEJaS34NYwXC9eJ/vUO7KUI1YTb4zMm9j7mXDst9SIWlqBlW2MZ9dSfgLVgxGv9O5PoeGd4O8r)
+    username: ENC(ijcbzqW1EZ2O9YzxPMm8gg==)
+    password: ENC(R+XbIS1cbxMAxGr08Ggepg==)
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,24 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url:
+    username:
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+    database-platform: org.hibernate.dialect.MySQLDialect
+
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+
+server:
+  port: 9090

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,24 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url:
+    username:
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+    database-platform: org.hibernate.dialect.MySQLDialect
+
+    properties:
+      hibernate:
+        format_sql: false
+        show_sql: false
+
+server:
+  port: 8080

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -13,8 +13,6 @@ spring:
     hibernate:
       ddl-auto: none
 
-    database-platform: org.hibernate.dialect.MySQLDialect
-
     properties:
       hibernate:
         format_sql: false

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -5,9 +5,9 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url:
-    username:
-    password:
+    url: ENC(kng63WZ9gkAwrkfCz30VI/p24G51DNm/XmT3OotgCAnlH2Fg2IzCP6i51ltgPNSMFjb5Ntc0bU8dDBuiXcJFBYboAVK1/zwV)
+    username: ENC(ijcbzqW1EZ2O9YzxPMm8gg==)
+    password: ENC(R+XbIS1cbxMAxGr08Ggepg==)
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles:
     group:
-      dev: dev, common
-      prod: prod, common
-    active: dev
+      develop: dev, common
+      production: prod, common
+      test: test, common
+    active: develop

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  profiles:
+    group:
+      dev: dev, common
+      prod: prod, common
+    active: dev

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -14,4 +14,7 @@ spring:
         format_sql: true
         show_sql: true
 
-    database-platform: org.hibernate.dialect.H2Dialect
+  h2:
+    console:
+      enabled: true
+      path: h2-console

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -15,6 +15,3 @@ spring:
         show_sql: true
 
     database-platform: org.hibernate.dialect.H2Dialect
-
-  jasypt:
-    encryptor:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,20 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+
+    database-platform: org.hibernate.dialect.H2Dialect
+
+  jasypt:
+    encryptor:


### PR DESCRIPTION
### 진행 사항
1. 작업환경 별 설정파일 분리
- dev(로컬 및 EC2 mysql dev DB 연결)
- prod(EC2 mysql prod DB 연결)
- test(단위테스트 시 In-memory DB인 h2 연결)

2. 설정파일 암호화
- Jasypt 라이브러리 사용
- 복호화에 사용되는 비밀키는 환경변수로 설정

3. develop 환경으로 배포 스크립트 수정
- 배포 스크립트 및 EC2 내부 환경변수로 Jasypt 비밀키 등록
- 빌드 step 수행 시 develop profile을 덮어씌워 항상 develop 설정파일을 사용하도록 설정

### 주의 사항
- IDE 또는 로컬 환경에도 Jasypt 비밀키를 인식할 수 있도록 환경변수 설정을 해야합니다.
- 암호화한 설정정보가 변경된다면 다시 비밀키를 사용하여 암호화를 해야합니다.

### 참고 자료
- [다중 Profile 분리방법](https://colabear754.tistory.com/112)
- [Jasypt 사용법](https://velog.io/@joonghyun/Jasypt%EC%99%80-Github-Secrets%EB%A1%9C-Github-%EA%B0%9C%EC%9D%B8-%EC%A0%95%EB%B3%B4-%EC%9C%A0%EC%B6%9C-%EB%B0%A9%EC%A7%80%ED%95%98%EA%B8%B0)
- [Jasypt 암호화 사이트](https://www.devglan.com/online-tools/jasypt-online-encryption-decryption)