### PR TITLE
TOT-48 : [FIX] 프론트엔드 초기세팅 문제(Theme, eslint 설정) 

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -30,6 +30,8 @@
   //원하는 규칙 추가 가능
   "rules": {
     "react/react-in-jsx-scope": "off",
+    "no-use-before-define": "off",
+    "@typescript-eslint/no-use-before-define": "off",
     "react/function-component-definition": [
       2,
       { "namedComponents": ["arrow-function", "function-declaration"] }

--- a/frontend/src/styles/style.d.ts
+++ b/frontend/src/styles/style.d.ts
@@ -1,0 +1,17 @@
+import 'styled-components';
+import { Theme } from './theme';
+
+interface Colors {
+  mainColor: string;
+  darkGrey: string;
+  lightGrey: string;
+  blackFont: string;
+  lightGreyFont: string;
+  whiteFont: string;
+}
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends Theme {
+    colors: Colors;
+  }
+}

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,10 +1,14 @@
-export const color = {
-  mainColor: 'FC6457',
-  darkGrey: '9A9A9A',
-  lightGrey: 'D9D9D9',
-  blackFont: '3A3939',
-  lightGreyFont: 'F6F6F6',
-  whiteFont: 'FFFFFF',
+const theme = {
+  colors: {
+    mainColor: '#FC6457',
+    darkGrey: '#9A9A9A',
+    lightGrey: '#D9D9D9',
+    blackFont: '#3A3939',
+    lightGreyFont: '#F6F6F6',
+    whiteFont: '#FFFFFF',
+  },
 };
 
-export default { color };
+export type Theme = typeof theme;
+
+export default theme;


### PR DESCRIPTION
## PR전 체크리스트
> 1. PR 및 Commit title을 형식에 맞게 작성했나요(e.g. TOT-123 : [TYPE])
네
> 2. Reviewers가 명확하게 지정됐나요?
네
> 3. Assignees가 명확하게 지정됐나요?
네

## 📝 작업 내용
1. 선언전에 스타일 컴포넌트를 사용할 수 있도록 eslint 설정 수정 
2. theme 파일 색상 수정 및 자동완성을 위한 ts파일 추가

### 스크린샷


## 💬 리뷰 요구사항
1. 수정사항이 문제없이 동작하는지 확인 부탁드립니다.
2. 저는 ` "@typescript-eslint/no-use-before-define": ["error"]` 이렇게 하면 에러가 발생해서  
`"@typescript-eslint/no-use-before-define": "off"`로 하니 문제가 발생하지 않았습니다. 
이부분 문제없는지 확인 부탁드립니다. 

## 참고자료
- [eslint 설정 수정 사항](https://stackoverflow.com/questions/63818415/react-was-used-before-it-was-defined)
- [styled-components에 ts 추가하기](https://sezzled.tistory.com/27)