### PR TITLE
TOT-31 : [FEAT] 모달창 내부 여행지 이미지 업로드 구현

### DIFF
--- a/frontend/src/components/LoginModal/LoginModal.tsx
+++ b/frontend/src/components/LoginModal/LoginModal.tsx
@@ -41,7 +41,7 @@ export const StyledModalLayout = styled.div`
 
   background-color: ${(props) => props.theme.colors.whiteFont};
 
-  box-shadow: 2px 2px 3px 0px darkgray;
+  box-shadow: 2px 2px 3px 0px ${(props) => props.theme.colors.darkGrey};
 `;
 
 export const StyledModalText = styled.h1`

--- a/frontend/src/components/common/modal/ImageBox/ImgaeBox.tsx
+++ b/frontend/src/components/common/modal/ImageBox/ImgaeBox.tsx
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+interface Props {
+  imageOrigin: string;
+}
+
+const ImageBox = ({ imageOrigin }: Props) => {
+  return <StyledImageBox imageOrigin={imageOrigin} />;
+};
+
+export default ImageBox;
+
+const StyledImageBox = styled.div<{ imageOrigin: string }>`
+  width: 457px;
+  height: 217px;
+
+  border-radius: 30px;
+  box-shadow: 1px 1px 1px 0px darkgray;
+
+  background-image: url(${(props) => props.imageOrigin});
+  background-size: cover;
+  background-position: center;
+`;

--- a/frontend/src/components/common/modal/ImageBox/ImgaeBox.tsx
+++ b/frontend/src/components/common/modal/ImageBox/ImgaeBox.tsx
@@ -19,5 +19,5 @@ const StyledImageBox = styled.div<{ imageOrigin: string }>`
   background-position: center;
 
   border-radius: 30px;
-  box-shadow: 1px 1px 1px 0px darkgray;
+  box-shadow: 1px 1px 1px 0px ${(props) => props.theme.colors.darkGrey};
 `;

--- a/frontend/src/components/common/modal/ImageBox/ImgaeBox.tsx
+++ b/frontend/src/components/common/modal/ImageBox/ImgaeBox.tsx
@@ -14,10 +14,10 @@ const StyledImageBox = styled.div<{ imageOrigin: string }>`
   width: 457px;
   height: 217px;
 
-  border-radius: 30px;
-  box-shadow: 1px 1px 1px 0px darkgray;
-
   background-image: url(${(props) => props.imageOrigin});
   background-size: cover;
   background-position: center;
+
+  border-radius: 30px;
+  box-shadow: 1px 1px 1px 0px darkgray;
 `;

--- a/frontend/src/components/common/modal/ImageBox/index.ts
+++ b/frontend/src/components/common/modal/ImageBox/index.ts
@@ -1,0 +1,3 @@
+import ImageBox from './ImgaeBox';
+
+export default ImageBox;


### PR DESCRIPTION
## PR전 체크리스트
> 1. PR 및 Commit title을 형식에 맞게 작성했나요(e.g. TOT-123 : [TYPE])
✅
> 2. Reviewers가 명확하게 지정됐나요?
✅
> 3. Assignees가 명확하게 지정됐나요?
✅


## 📝 작업 내용
- 모달창 내부에서 여행지 이미지 업로드하는 컴포넌트 작업
- 그림자 효과 작업 => 혹여나 화면의 겉부분이 흰색이라면 배경화면도 흰색이기 때문에 경계가 모호하여 주었고 스크린샷을 보시면 좋을 것 같습니다. 

### 스크린샷
<img width="1055" alt="스크린샷 2024-02-25 오후 4 41 25" src="https://github.com/trip-or-treat/trip-or-treat/assets/88155610/0b8022d8-1cae-4941-82af-36672676f3dc">


## 💬 리뷰 요구사항

## 참고자료

