### PR TITLE
TOT-52 : [CHORE] main, develop 브랜치별 다른 서버 배포 구성

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,11 @@ name: Build and Deploy to EC2
 
 on:
   push:
-    branches: [ "develop" ]
+    branches:
+      - develop
+      - CHORE/TOT-52
+		paths:
+			- './backend/**'
 
 env:
   PROJECT_NAME: triportreat_project
@@ -31,8 +35,8 @@ jobs:
         run: chmod +x ./gradlew
         shell: bash
 
-      - name: Build and Test(사용하는 프로파일은 develop, 암호화키는 환경변수로 등록 후 빌드 실행)
-        run: ./gradlew build -Dspring.profiles.active=develop
+      - name: Build and Test
+        run: ./gradlew build -Dspring.profiles.active=${{ github.ref == 'refs/heads/CHORE/TOT-52' && 'production' || 'develop' }}
         shell: bash
 
       - name: Make Zip File

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy to EC2
 on:
   push:
     branches:
-      - CHORE/TOT-52
+      - main
       - develop
     paths:
       - 'backend/**'
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and Test
         run: |
-          jarName=$( [ "${{ steps.get_branch.outputs.branch }}" = "CHORE/TOT-52" ] && echo "main" || echo "develop" )
+          jarName=$( [ "${{ steps.get_branch.outputs.branch }}" = "main" ] && echo "main" || echo "develop" )
           ./gradlew build -PjarName="$jarName"
         shell: bash
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,10 +3,10 @@ name: Build and Deploy to EC2
 on:
   push:
     branches:
-      - develop
+      - main
       - CHORE/TOT-52
-		paths:
-			- './backend/**'
+    paths:
+      - 'backend/**'
 
 env:
   PROJECT_NAME: triportreat_project
@@ -31,12 +31,18 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Determine branch name
+        id: get_branch
+        run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
+
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
         shell: bash
 
       - name: Build and Test
-        run: ./gradlew build -Dspring.profiles.active=${{ github.ref == 'refs/heads/CHORE/TOT-52' && 'production' || 'develop' }}
+        run: |
+          jarName=$( [ "${{ steps.get_branch.outputs.branch }}" = "CHORE/TOT-52" ] && echo "main" || echo "develop" )
+          ./gradlew build -PjarName="$jarName"
         shell: bash
 
       - name: Make Zip File

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Build and Deploy to EC2
 on:
   push:
     branches:
-      - main
+      - CHORE/TOT-52
       - develop
     paths:
       - 'backend/**'
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and Test
         run: |
-          jarName=$( [ "${{ steps.get_branch.outputs.branch }}" = "main" ] && echo "main" || echo "develop" )
+          jarName=$( [ "${{ steps.get_branch.outputs.branch }}" = "CHORE/TOT-52" ] && echo "main" || echo "develop" )
           ./gradlew build -PjarName="$jarName"
         shell: bash
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - CHORE/TOT-52
+      - develop
     paths:
       - 'backend/**'
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and Test
         run: |
-          jarName=$( [ "${{ steps.get_branch.outputs.branch }}" = "CHORE/TOT-52" ] && echo "main" || echo "develop" )
+          jarName=$( [ "${{ steps.get_branch.outputs.branch }}" = "main" ] && echo "main" || echo "develop" )
           ./gradlew build -PjarName="$jarName"
         shell: bash
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,7 +51,7 @@ tasks.named('test') {
 
 jar {
     enabled = false
-    def jarName = project.getProperty('jarName')
+    def jarName = project.findProperty('jarName') ?: "triportreat"
     println "Jarname : ${jarName}"
     archivesBaseName = jarName
 }   

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -51,4 +51,7 @@ tasks.named('test') {
 
 jar {
     enabled = false
-}
+    def jarName = project.getProperty('jarName')
+    println "Jarname : ${jarName}"
+    archivesBaseName = jarName
+}   

--- a/backend/scripts/deploy.sh
+++ b/backend/scripts/deploy.sh
@@ -1,63 +1,50 @@
 #!/usr/bin/env bash
 
+echo "#############################"
+
 REPOSITORY=/home/ubuntu/triportreat
 cd $REPOSITORY
 
 JAR_NAME=$(ls $REPOSITORY/build/libs/ | grep 'SNAPSHOT.jar' | tail -n 1)
 JAR_PATH=$REPOSITORY/build/libs/$JAR_NAME
 
-# 실행되고 있는 운영서버 PID
+# 운영서버, 개발서버 pid
 MAIN_PID=$(pgrep -f production)
-# 실행되고 있는 개발 서버 PID
 DEV_PID=$(pgrep -f develop)
 
-# 정상 실행 로그 파일
+# 로그 파일 경로
 MAIN_LOG_OUT="/home/ubuntu/logs/main.out"
 DEV_LOG_OUT="/home/ubuntu/logs/dev.out"
-# 에러 로그 파일
 MAIN_LOG_ERR="/home/ubuntu/logs/main.err"
 DEV_LOG_ERR="/home/ubuntu/logs/dev.err"
 
 
-# 혹시 개발서버가 실행중일 경우 종료
-if [ -n $DEV_PID ]; 
-then
-	echo "개발서버 실행중...종료합니다"
-	kill -15 $DEV_PID
-	sleep 5
-else 
-	echo "개발서버가 실행중이 아닙니다"
-fi
+if [[ "$JAR_NAME" == *"main"* ]]; then
+  echo "운영서버를 배포합니다..."
 
-
-# 메인브랜치로 푸시될 경우
-# TODO main브랜치로 수정
-if [ "$GITHUB_REF" = "refs/heads/CHORE/TOT-52" ]; then
-	echo "메인브랜치가 푸시되었습니다. 메인 프로파일로 실행합니다."
-
-  # 이전에 실행된 프로세스의 PID를 찾아 종료
-  if [ -n $MAIN_PID ]; 
-	then
-    echo "메인 프로세스를 종료합니다..."
+  if [ -n $MAIN_PID ]; then
+    echo "운영서버 실행중...종료합니다"
     kill -15 $MAIN_PID
     sleep 5
-  else
-    echo "메인 프로세스가 실행중이 아닙니다..."
+  else 
+    echo "운영서버가 실행중이 아닙니다"
   fi
-	
-	echo "메인 프로세스를 실행합니다..."
-	nohup java -jar -Dspring.profiles.active=production $JAR_PATH >$MAIN_LOG_OUT 2>$MAIN_LOG_ERR < /dev/null &
+
+  echo "운영서버를 시작합니다..."
+  nohup java -jar -Dspring.profiles.active=production $JAR_PATH >$MAIN_LOG_OUT 2>$MAIN_LOG_ERR < /dev/null &
 
 else
-  # 개발 브랜치로 푸시될 경우
-  echo "개발브랜치가 푸시되었습니다. 개발 프로파일로 잠시 실행합니다."
-  
-  # 프로세스 시작
-  echo "develop 프로파일로 실행합니다..."
+  echo "개발서버를 배포합니다..."
+
+  if [ -n $DEV_PID ]; then
+    echo "개발서버 실행중...종료합니다"
+    kill -15 $DEV_PID
+    sleep 5
+  else 
+    echo "개발서버가 실행중이 아닙니다..."
+  fi
+
+  echo "개발서버를 시작합니다..."
   nohup java -jar -Dspring.profiles.active=develop $JAR_PATH >$DEV_LOG_OUT 2>$DEV_LOG_ERR < /dev/null &
-  
-  # 프로세스 시작 후 바로 종료
-  echo "개발 프로세스를 종료합니다..."
-	kill -15 $DEV_PID
-	sleep 5
+
 fi

--- a/backend/scripts/deploy.sh
+++ b/backend/scripts/deploy.sh
@@ -3,20 +3,61 @@
 REPOSITORY=/home/ubuntu/triportreat
 cd $REPOSITORY
 
-APP_NAME=triportreat
 JAR_NAME=$(ls $REPOSITORY/build/libs/ | grep 'SNAPSHOT.jar' | tail -n 1)
 JAR_PATH=$REPOSITORY/build/libs/$JAR_NAME
 
-CURRENT_PID=$(pgrep -f $APP_NAME)
+# 실행되고 있는 운영서버 PID
+MAIN_PID=$(pgrep -f production)
+# 실행되고 있는 개발 서버 PID
+DEV_PID=$(pgrep -f develop)
 
-if [ -z $CURRENT_PID ]
+# 정상 실행 로그 파일
+MAIN_LOG_OUT="/home/ubuntu/logs/main.out"
+DEV_LOG_OUT="/home/ubuntu/logs/dev.out"
+# 에러 로그 파일
+MAIN_LOG_ERR="/home/ubuntu/logs/main.err"
+DEV_LOG_ERR="/home/ubuntu/logs/dev.err"
+
+
+# 혹시 개발서버가 실행중일 경우 종료
+if [ -n $DEV_PID ]; 
 then
-  echo "> 종료할것 없음."
-else
-  echo "> kill -9 $CURRENT_PID"
-  kill -15 $CURRENT_PID
-  sleep 5
+	echo "개발서버 실행중...종료합니다"
+	kill -15 $DEV_PID
+	sleep 5
+else 
+	echo "개발서버가 실행중이 아닙니다"
 fi
 
-echo "> $JAR_PATH 배포"
-nohup java -jar -Dspring.profiles.active=develop $JAR_PATH > /dev/null 2> /dev/null < /dev/null &
+
+# 메인브랜치로 푸시될 경우
+# TODO main브랜치로 수정
+if [ "$GITHUB_REF" = "refs/heads/CHORE/TOT-52" ]; then
+	echo "메인브랜치가 푸시되었습니다. 메인 프로파일로 실행합니다."
+
+  # 이전에 실행된 프로세스의 PID를 찾아 종료
+  if [ -n $MAIN_PID ]; 
+	then
+    echo "메인 프로세스를 종료합니다..."
+    kill -15 $MAIN_PID
+    sleep 5
+  else
+    echo "메인 프로세스가 실행중이 아닙니다..."
+  fi
+	
+	echo "메인 프로세스를 실행합니다..."
+	nohup java -jar -Dspring.profiles.active=production $JAR_PATH >$MAIN_LOG_OUT 2>$MAIN_LOG_ERR < /dev/null &
+
+else
+  # 개발 브랜치로 푸시될 경우
+  echo "개발브랜치가 푸시되었습니다. 개발 프로파일로 잠시 실행합니다."
+  
+  # 프로세스 시작
+  echo "develop 프로파일로 실행합니다..."
+  nohup java -jar -Dspring.profiles.active=develop $JAR_PATH >$DEV_LOG_OUT 2>$DEV_LOG_ERR < /dev/null &
+  
+  # 프로세스 시작 후 바로 종료
+  echo "개발 프로세스를 종료합니다..."
+	kill -15 $DEV_PID
+	sleep 5
+fi


### PR DESCRIPTION
## PR전 체크리스트
> 1. PR 및 Commit title을 형식에 맞게 작성했나요(e.g. TOT-123 : [TYPE]) O
> 2. Reviewers가 명확하게 지정됐나요? O
> 3. Assignees가 명확하게 지정됐나요? O


## 📝 작업 내용
- 백엔드 폴더 내에 코드 변화가 생기고 `.github/workflows/deploy.yml`에서 main 브랜치로 푸시될경우 빌드되는 jar파일명을 'main'을, develop 브랜치로 푸시될경우 'develop'을 변수로 생성해 build.gradle로 전달.
- `build.gradle`에서 전달받은 이름으로 프로젝트가 빌드되도록 설정.
- `scripts/deploy.sh`에서 전달받은 빌드 결과물의 이름에 'main'이 포함될경우 운영서버를 production 프로파일로 재실행, 포함되어 있지  않을 경우 개발서버를 develop 프로파일로 재실행.
- 실행시 ec2 인스턴스의 /home/ubuntu/logs 폴더 내에 운영서버는 정상실행로그, 오류실행로그로 각각 main.out, main.err 로그파일을 저장, 개발서버는 dev.out, dev.err 로그파일로 저장.
- CodeDeploy로 실행된 스크립트 내역을 보고 싶다면 `/opt/codedeploy-agent/deployment-root/deployment-logs/codedeploy-agent-deployments.log` 파일을 확인.


### 스크린샷


## 💬 리뷰 요구사항


## 참고자료

