### PR TITLE
TOT-51 : [FEAT] 장소 공통정보 조회 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation "com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5"
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
     testImplementation 'org.projectlombok:lombok:1.18.28'
     compileOnly 'org.projectlombok:lombok'
     testImplementation 'com.h2database:h2'

--- a/backend/src/main/java/com/triportreat/backend/common/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/triportreat/backend/common/config/RestTemplateConfig.java
@@ -1,10 +1,14 @@
 package com.triportreat.backend.common.config;
 
-import java.time.Duration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
 
 @Configuration
 public class RestTemplateConfig {
@@ -15,5 +19,20 @@ public class RestTemplateConfig {
                 .setConnectTimeout(Duration.ofSeconds(10))
                 .setReadTimeout(Duration.ofSeconds(60))
                 .build();
+    }
+
+    @Bean
+    public RetryTemplate retryTemplate() {
+        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
+        retryPolicy.setMaxAttempts(5);
+
+        FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
+        backOffPolicy.setBackOffPeriod(2000L);
+
+        RetryTemplate retryTemplate = new RetryTemplate();
+        retryTemplate.setRetryPolicy(retryPolicy);
+        retryTemplate.setBackOffPolicy(backOffPolicy);
+
+        return retryTemplate;
     }
 }

--- a/backend/src/main/java/com/triportreat/backend/common/response/FailMessage.java
+++ b/backend/src/main/java/com/triportreat/backend/common/response/FailMessage.java
@@ -7,7 +7,10 @@ public enum FailMessage {
     GET_FAIL("조회에 실패하였습니다."),
     UNKNOWN_ERROR("알 수 없는 오류가 발생하였습니다."),
     REGION_NOT_FOUND("지역 정보가 존재하지 않습니다!"),
-    RECOMMENDED_PLACE_EMPTY("추천 장소 정보가 존재하지 않습니다!");
+    RECOMMENDED_PLACE_EMPTY("추천 장소 정보가 존재하지 않습니다!"),
+    PLACE_NOT_FOUND("장소 정보가 존재하지 않습니다: "),
+    API_CALL_FAILED("외부 API 호출에 실패하였습니다."),
+    API_RESPONSE_PARSE_FAILED("외부 API 응답 처리에 실패하였습니다.");
 
     private final String message;
 

--- a/backend/src/main/java/com/triportreat/backend/place/controller/ContentTypeController.java
+++ b/backend/src/main/java/com/triportreat/backend/place/controller/ContentTypeController.java
@@ -15,7 +15,7 @@ public class ContentTypeController {
 
     private final ContentTypeService contentTypeService;
 
-    @GetMapping("/places/content_type")
+    @GetMapping("/places/content-type")
     public ResponseEntity<?> getContentTypes() {
         return ResponseEntity.ok().body(
                 ResponseResult.success(GET_SUCCESS.getMessage(), contentTypeService.getContentTypes()));

--- a/backend/src/main/java/com/triportreat/backend/place/controller/PlaceController.java
+++ b/backend/src/main/java/com/triportreat/backend/place/controller/PlaceController.java
@@ -1,7 +1,5 @@
 package com.triportreat.backend.place.controller;
 
-import static com.triportreat.backend.common.response.SuccessMessage.GET_SUCCESS;
-
 import com.triportreat.backend.common.response.ResponseResult;
 import com.triportreat.backend.place.domain.PlaceSearchCondition;
 import com.triportreat.backend.place.service.PlaceService;
@@ -11,8 +9,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.triportreat.backend.common.response.SuccessMessage.GET_SUCCESS;
 
 @RestController
 @RequestMapping("/places")
@@ -31,5 +32,12 @@ public class PlaceController {
                         ResponseResult.success(
                                 GET_SUCCESS.getMessage(),
                                 placeService.searchPlaceListByCondition(placeSearchCondition, pageable)));
+    }
+
+    @GetMapping("/common/{id}")
+    public ResponseEntity<?> getPlaceCommonInfo(@PathVariable("id") Long id) {
+        return ResponseEntity.ok().body(
+                ResponseResult.success(GET_SUCCESS.getMessage(), placeService.getPlaceCommonInfo(id))
+        );
     }
 }

--- a/backend/src/main/java/com/triportreat/backend/place/domain/PlaceCommonInfoDto.java
+++ b/backend/src/main/java/com/triportreat/backend/place/domain/PlaceCommonInfoDto.java
@@ -1,0 +1,26 @@
+package com.triportreat.backend.place.domain;
+
+import com.triportreat.backend.place.entity.ContentType;
+import com.triportreat.backend.place.entity.Place;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PlaceCommonInfoDto {
+    private String name;
+    private String imageOrigin;
+    private String overview;
+    private Long contentTypeId;
+
+    public static  PlaceCommonInfoDto toDto(Place place, ContentType contentType, String overview) {
+        return PlaceCommonInfoDto.builder()
+                .name(place.getName())
+                .imageOrigin(place.getImageOrigin())
+                .overview(overview)
+                .contentTypeId(contentType.getId())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/place/error/handler/PlaceExceptionHandler.java
+++ b/backend/src/main/java/com/triportreat/backend/place/error/handler/PlaceExceptionHandler.java
@@ -1,10 +1,8 @@
 package com.triportreat.backend.place.error.handler;
 
+import com.triportreat.backend.common.AbstractException;
 import com.triportreat.backend.common.response.ResponseResult;
 import com.triportreat.backend.place.controller.PlaceController;
-import com.triportreat.backend.place.error.handler.exception.ApiCallFailedException;
-import com.triportreat.backend.place.error.handler.exception.ApiResponseParseException;
-import com.triportreat.backend.place.error.handler.exception.PlaceNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -35,20 +33,8 @@ public class PlaceExceptionHandler {
         return ResponseEntity.ok().body(ResponseResult.fail(GET_FAIL.getMessage(), BAD_REQUEST, errors));
     }
 
-    @ExceptionHandler(PlaceNotFoundException.class)
-    protected ResponseEntity<?> placeNotFoundExceptionHandler(PlaceNotFoundException e) {
-        return ResponseEntity.ok()
-                .body(ResponseResult.fail(e.getMessage(), e.getStatus(), null));
-    }
-
-    @ExceptionHandler(ApiCallFailedException.class)
-    protected ResponseEntity<?> apiCallFailedExceptionHandler(ApiCallFailedException e) {
+    @ExceptionHandler(AbstractException.class)
+    protected ResponseEntity<?> abstractExceptionHandler(AbstractException e) {
         return ResponseEntity.ok().body(ResponseResult.fail(e.getMessage(), e.getStatus(), null));
     }
-
-    @ExceptionHandler(ApiResponseParseException.class)
-    protected ResponseEntity<?> apiResponseParseExceptionHandler(ApiResponseParseException e) {
-        return ResponseEntity.ok().body(ResponseResult.fail(e.getMessage(), e.getStatus(), null));
-    }
-
 }

--- a/backend/src/main/java/com/triportreat/backend/place/error/handler/PlaceExceptionHandler.java
+++ b/backend/src/main/java/com/triportreat/backend/place/error/handler/PlaceExceptionHandler.java
@@ -1,19 +1,23 @@
 package com.triportreat.backend.place.error.handler;
 
-import static com.triportreat.backend.common.response.FailMessage.GET_FAIL;
-import static com.triportreat.backend.common.response.FailMessage.UNKNOWN_ERROR;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
-
 import com.triportreat.backend.common.response.ResponseResult;
 import com.triportreat.backend.place.controller.PlaceController;
-import java.util.Map;
-import java.util.stream.Collectors;
+import com.triportreat.backend.place.error.handler.exception.ApiCallFailedException;
+import com.triportreat.backend.place.error.handler.exception.ApiResponseParseException;
+import com.triportreat.backend.place.error.handler.exception.PlaceNotFoundException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.triportreat.backend.common.response.FailMessage.GET_FAIL;
+import static com.triportreat.backend.common.response.FailMessage.UNKNOWN_ERROR;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 @RestControllerAdvice(basePackageClasses = PlaceController.class)
 public class PlaceExceptionHandler {
@@ -29,6 +33,22 @@ public class PlaceExceptionHandler {
                 .stream()
                 .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage));
         return ResponseEntity.ok().body(ResponseResult.fail(GET_FAIL.getMessage(), BAD_REQUEST, errors));
+    }
+
+    @ExceptionHandler(PlaceNotFoundException.class)
+    protected ResponseEntity<?> placeNotFoundExceptionHandler(PlaceNotFoundException e) {
+        return ResponseEntity.ok()
+                .body(ResponseResult.fail(e.getMessage(), e.getStatus(), null));
+    }
+
+    @ExceptionHandler(ApiCallFailedException.class)
+    protected ResponseEntity<?> apiCallFailedExceptionHandler(ApiCallFailedException e) {
+        return ResponseEntity.ok().body(ResponseResult.fail(e.getMessage(), e.getStatus(), null));
+    }
+
+    @ExceptionHandler(ApiResponseParseException.class)
+    protected ResponseEntity<?> apiResponseParseExceptionHandler(ApiResponseParseException e) {
+        return ResponseEntity.ok().body(ResponseResult.fail(e.getMessage(), e.getStatus(), null));
     }
 
 }

--- a/backend/src/main/java/com/triportreat/backend/place/error/handler/exception/ApiCallFailedException.java
+++ b/backend/src/main/java/com/triportreat/backend/place/error/handler/exception/ApiCallFailedException.java
@@ -1,0 +1,19 @@
+package com.triportreat.backend.place.error.handler.exception;
+
+import com.triportreat.backend.common.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static com.triportreat.backend.common.response.FailMessage.API_CALL_FAILED;
+
+public class ApiCallFailedException extends AbstractException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return API_CALL_FAILED.getMessage();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/place/error/handler/exception/ApiResponseParseException.java
+++ b/backend/src/main/java/com/triportreat/backend/place/error/handler/exception/ApiResponseParseException.java
@@ -1,0 +1,19 @@
+package com.triportreat.backend.place.error.handler.exception;
+
+import com.triportreat.backend.common.AbstractException;
+import org.springframework.http.HttpStatus;
+
+import static com.triportreat.backend.common.response.FailMessage.API_RESPONSE_PARSE_FAILED;
+
+public class ApiResponseParseException extends AbstractException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return API_RESPONSE_PARSE_FAILED.getMessage();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/place/error/handler/exception/PlaceNotFoundException.java
+++ b/backend/src/main/java/com/triportreat/backend/place/error/handler/exception/PlaceNotFoundException.java
@@ -1,0 +1,25 @@
+package com.triportreat.backend.place.error.handler.exception;
+
+import com.triportreat.backend.common.AbstractException;
+import com.triportreat.backend.common.response.FailMessage;
+import org.springframework.http.HttpStatus;
+
+public class PlaceNotFoundException extends AbstractException {
+
+    private final Long id;
+
+    public PlaceNotFoundException(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public String getMessage() {
+        return FailMessage.PLACE_NOT_FOUND.getMessage() + id;
+    }
+}
+

--- a/backend/src/main/java/com/triportreat/backend/place/service/ExternalApiService.java
+++ b/backend/src/main/java/com/triportreat/backend/place/service/ExternalApiService.java
@@ -1,0 +1,56 @@
+package com.triportreat.backend.place.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.triportreat.backend.place.error.handler.exception.ApiCallFailedException;
+import com.triportreat.backend.place.error.handler.exception.ApiResponseParseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class ExternalApiService {
+    private final RestTemplate restTemplate;
+    private final RetryTemplate retryTemplate;
+
+    @Value("${openapi.overviewUrl}")
+    private String overviewUrl;
+
+    @Value("${openapi.key}")
+    private String serviceKey;
+
+    public String callExternalApiForOverView(Long id) {
+        String url = overviewUrl + "&serviceKey=" + serviceKey + "&contentId=" + id + "&overviewYN=Y";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>("parameters", headers);
+        ResponseEntity<String> response;
+        try {
+            response = retryTemplate.execute(context -> restTemplate.exchange(url, HttpMethod.GET, entity, String.class));
+        } catch (RestClientException e) {
+            throw new ApiCallFailedException();
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode root;
+        try {
+            root = mapper.readTree(response.getBody());
+        } catch (JsonProcessingException e) {
+            throw new ApiResponseParseException();
+        }
+        String overview = root.path("response").path("body").path("items").path("item").get(0).path("overview").asText();
+
+        if (overview == null || overview.isEmpty()) {
+            throw new ApiResponseParseException();
+        }
+
+        return overview;
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/place/service/PlaceService.java
+++ b/backend/src/main/java/com/triportreat/backend/place/service/PlaceService.java
@@ -1,10 +1,14 @@
 package com.triportreat.backend.place.service;
 
 import com.triportreat.backend.place.domain.PlaceByRegionIdDto;
+import com.triportreat.backend.place.domain.PlaceCommonInfoDto;
 import com.triportreat.backend.place.domain.PlaceSearchCondition;
-import java.util.List;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface PlaceService {
     List<PlaceByRegionIdDto> searchPlaceListByCondition(PlaceSearchCondition placeSearchCondition, Pageable pageable);
+
+    PlaceCommonInfoDto getPlaceCommonInfo(Long id);
 }

--- a/backend/src/main/java/com/triportreat/backend/place/service/impl/PlaceServiceImpl.java
+++ b/backend/src/main/java/com/triportreat/backend/place/service/impl/PlaceServiceImpl.java
@@ -1,15 +1,21 @@
 package com.triportreat.backend.place.service.impl;
 
 import com.triportreat.backend.place.domain.PlaceByRegionIdDto;
+import com.triportreat.backend.place.domain.PlaceCommonInfoDto;
 import com.triportreat.backend.place.domain.PlaceSearchCondition;
+import com.triportreat.backend.place.entity.ContentType;
+import com.triportreat.backend.place.entity.Place;
+import com.triportreat.backend.place.error.handler.exception.PlaceNotFoundException;
 import com.triportreat.backend.place.repository.PlaceRepository;
 import com.triportreat.backend.place.repository.PlaceRepositoryCustom;
+import com.triportreat.backend.place.service.ExternalApiService;
 import com.triportreat.backend.place.service.PlaceService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -17,10 +23,21 @@ public class PlaceServiceImpl implements PlaceService {
 
     private final PlaceRepositoryCustom placeRepositoryCustom;
     private final PlaceRepository placeRepository;
+    private final ExternalApiService externalApiService;
 
     @Override
     @Transactional(readOnly = true)
     public List<PlaceByRegionIdDto> searchPlaceListByCondition(PlaceSearchCondition placeSearchCondition, Pageable pageable) {
         return placeRepositoryCustom.searchPlaceListByCondition(placeSearchCondition, pageable);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PlaceCommonInfoDto getPlaceCommonInfo(Long id) {
+        Place place = placeRepository.findById(id).orElseThrow(() -> new PlaceNotFoundException(id));
+        ContentType contentType = place.getContentType();
+        String overview = externalApiService.callExternalApiForOverView(id);
+        return PlaceCommonInfoDto.toDto(place, contentType, overview);
+    }
 }
+

--- a/backend/src/main/resources/application-common.yml
+++ b/backend/src/main/resources/application-common.yml
@@ -10,6 +10,7 @@ spring:
 
 openapi:
   url: ENC(LLU9kjm25zSyg5yOyVPUXOv+5S90hpA4nf361o39gyCQseJX2RDJrDMSLPujhrq/TCmjv2PKnveaorj78K1640eKP91zTpiwzfJWOl1bB8nQWOJBxaiYZemCEBlBrF0xG5j/N898ydeUWrWl12uuJw==)
+  overviewUrl: ENC(fJ2nwclOmMDzWfbtJc+n260rUvkQPCztus0m7PXF8ah2xi8dkwoKWJJWD4J5kQpwhibbqdI2Sk4AYCg3ka/2GVx+zgVOa4H1bhrQhUzOuYr8LCYCKqD2VbYv18Ka3t2d2VMvCUTQMsl9UfOSi2oeYA==)
   key: ENC(D5hw5G8H2Ngep4NJFvgNB0ZWylYDw1+805rEsGA0L6zbbgGshGoKb4OiFtwuUjMW6EH6JYNgwu4G0lW7EZiNZ6bV/C+7KfI157qWMO2dBjvisAVV6VEg7ca0c2zZWXTE9g4Fl5wuwuznQhcZDvTrfw==)
 
 schedule:

--- a/backend/src/test/java/com/triportreat/backend/place/controller/PlaceControllerTest.java
+++ b/backend/src/test/java/com/triportreat/backend/place/controller/PlaceControllerTest.java
@@ -1,23 +1,26 @@
 package com.triportreat.backend.place.controller;
 
-import static com.triportreat.backend.common.response.FailMessage.GET_FAIL;
-import static com.triportreat.backend.common.response.SuccessMessage.GET_SUCCESS;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.triportreat.backend.place.domain.PlaceByRegionIdDto;
+import com.triportreat.backend.place.domain.PlaceCommonInfoDto;
 import com.triportreat.backend.place.domain.PlaceSearchCondition;
 import com.triportreat.backend.place.service.PlaceService;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static com.triportreat.backend.common.response.FailMessage.GET_FAIL;
+import static com.triportreat.backend.common.response.SuccessMessage.GET_SUCCESS;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(PlaceController.class)
 class PlaceControllerTest {
@@ -109,4 +112,33 @@ class PlaceControllerTest {
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data").isEmpty());
     }
+
+    @Test
+    @DisplayName("특정 장소의 공통 정보를 조회하면 응답은 성공한다.")
+    void getPlaceCommonInfo_success() throws Exception {
+        // given
+        Long id = 1L;
+        PlaceCommonInfoDto placeCommonInfoDto = PlaceCommonInfoDto.builder()
+                .name("Test Place")
+                .imageOrigin("image.jpg")
+                .overview("Test Overview")
+                .contentTypeId(1L)
+                .build();
+
+        // when
+        when(placeService.getPlaceCommonInfo(id)).thenReturn(placeCommonInfoDto);
+
+        // then
+        mockMvc.perform(get("/places/common/" + id)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value(true))
+                .andExpect(jsonPath("$.message").value(GET_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.name").value(placeCommonInfoDto.getName()))
+                .andExpect(jsonPath("$.data.imageOrigin").value(placeCommonInfoDto.getImageOrigin()))
+                .andExpect(jsonPath("$.data.overview").value(placeCommonInfoDto.getOverview()))
+                .andExpect(jsonPath("$.data.contentTypeId").value(placeCommonInfoDto.getContentTypeId()));
+    }
+
 }

--- a/backend/src/test/java/com/triportreat/backend/place/service/impl/PlaceServiceImplTest.java
+++ b/backend/src/test/java/com/triportreat/backend/place/service/impl/PlaceServiceImplTest.java
@@ -104,8 +104,9 @@ class PlaceServiceImplTest {
         PlaceCommonInfoDto actualPlaceCommonInfoDto = placeService.getPlaceCommonInfo(id);
 
         assertThat(actualPlaceCommonInfoDto).isNotNull();
-        assertThat(actualPlaceCommonInfoDto).isEqualToComparingFieldByField(expectedPlaceCommonInfoDto);
+        assertThat(actualPlaceCommonInfoDto).usingRecursiveComparison().isEqualTo(expectedPlaceCommonInfoDto);
     }
+
 
     @Test
     @DisplayName("장소 공통정보 조회 실패 테스트 - 장소 정보가 존재하지 않음")

--- a/backend/src/test/java/com/triportreat/backend/place/service/impl/PlaceServiceImplTest.java
+++ b/backend/src/test/java/com/triportreat/backend/place/service/impl/PlaceServiceImplTest.java
@@ -1,14 +1,18 @@
 package com.triportreat.backend.place.service.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.when;
-
+import com.triportreat.backend.common.response.FailMessage;
 import com.triportreat.backend.place.domain.PlaceByRegionIdDto;
+import com.triportreat.backend.place.domain.PlaceCommonInfoDto;
 import com.triportreat.backend.place.domain.PlaceSearchCondition;
+import com.triportreat.backend.place.entity.ContentType;
+import com.triportreat.backend.place.entity.Place;
+import com.triportreat.backend.place.error.handler.exception.ApiCallFailedException;
+import com.triportreat.backend.place.error.handler.exception.ApiResponseParseException;
+import com.triportreat.backend.place.error.handler.exception.PlaceNotFoundException;
+import com.triportreat.backend.place.repository.PlaceRepository;
 import com.triportreat.backend.place.repository.PlaceRepositoryCustom;
+import com.triportreat.backend.place.service.ExternalApiService;
 import com.triportreat.backend.place.service.PlaceService;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,6 +20,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.when;
+import static org.mockito.Mockito.mock;
 
 @SpringBootTest
 class PlaceServiceImplTest {
@@ -25,6 +38,12 @@ class PlaceServiceImplTest {
 
     @MockBean
     private PlaceRepositoryCustom placeRepositoryCustom;
+
+    @MockBean
+    private PlaceRepository placeRepository;
+
+    @MockBean
+    private ExternalApiService externalApiService;
 
     @Test
     @DisplayName("검색 조건에 맞는 장소목록 조회")
@@ -53,5 +72,88 @@ class PlaceServiceImplTest {
             assertThat(place.getName()).contains("궁");
             assertThat(place.getContentTypeId()).isEqualTo(14L);
         }));
+    }
+
+    @Test
+    @DisplayName("공통 정보 조회 테스트")
+    void getPlaceCommonInfo() {
+        // given
+        Long id = 1L;
+        ContentType contentType = ContentType.builder().id(1L).name("Type1").build(); // ContentType 객체 생성
+        Place place = Place.builder()
+                .id(id)
+                .name("Test Place")
+                .imageOrigin("image.jpg")
+                .contentType(contentType)
+                .build();
+
+        String overview = "Test Overview";
+
+        PlaceCommonInfoDto expectedPlaceCommonInfoDto = PlaceCommonInfoDto.builder()
+                .name("Test Place")
+                .imageOrigin("image.jpg")
+                .overview("Test Overview")
+                .contentTypeId(1L)
+                .build();
+
+        // when
+        when(placeRepository.findById(id)).thenReturn(Optional.of(place));
+        when(externalApiService.callExternalApiForOverView(id)).thenReturn(overview);
+
+        // then
+        PlaceCommonInfoDto actualPlaceCommonInfoDto = placeService.getPlaceCommonInfo(id);
+
+        assertThat(actualPlaceCommonInfoDto).isNotNull();
+        assertThat(actualPlaceCommonInfoDto).isEqualToComparingFieldByField(expectedPlaceCommonInfoDto);
+    }
+
+    @Test
+    @DisplayName("장소 공통정보 조회 실패 테스트 - 장소 정보가 존재하지 않음")
+    void getPlaceCommonInfo_notExist() {
+        // given
+        Long id = 1L;
+
+        // when
+        when(placeRepository.findById(id)).thenReturn(Optional.empty());
+
+        // then
+        Exception exception = assertThrows(PlaceNotFoundException.class, () -> placeService.getPlaceCommonInfo(id));
+        assertThat(exception.getMessage()).isEqualTo(FailMessage.PLACE_NOT_FOUND.getMessage() + id);
+    }
+
+    @Test
+    @DisplayName("장소 공통정보 조회 실패 테스트 - 외부 API 호출 실패")
+    void getPlaceCommonInfo_ApiCallFailed() {
+        // given
+        Long id = 1L;
+        Place place = mock(Place.class);
+        ContentType contentType = mock(ContentType.class);
+
+        // when
+        when(placeRepository.findById(id)).thenReturn(Optional.of(place));
+        when(place.getContentType()).thenReturn(contentType);
+        when(externalApiService.callExternalApiForOverView(id)).thenThrow(new ApiCallFailedException());
+
+        // then
+        Exception exception = assertThrows(ApiCallFailedException.class, () -> placeService.getPlaceCommonInfo(id));
+        assertThat(exception.getMessage()).isEqualTo(FailMessage.API_CALL_FAILED.getMessage());
+    }
+
+    @Test
+    @DisplayName("장소 공통정보 조회 실패 테스트 - 외부 API 응답 처리 실패")
+    void getPlaceCommonInfo_ApiResponseParseFailed() {
+        // given
+        Long id = 1L;
+        Place place = mock(Place.class);
+        ContentType contentType = mock(ContentType.class);
+
+        // when
+        when(placeRepository.findById(id)).thenReturn(Optional.of(place));
+        when(place.getContentType()).thenReturn(contentType);
+        when(externalApiService.callExternalApiForOverView(id)).thenThrow(ApiResponseParseException.class);
+
+        // then
+        Exception exception = assertThrows(ApiResponseParseException.class, () -> placeService.getPlaceCommonInfo(id));
+        assertThat(exception.getMessage()).isEqualTo(FailMessage.API_RESPONSE_PARSE_FAILED.getMessage());
     }
 }


### PR DESCRIPTION
## PR전 체크리스트
> 1. PR 및 Commit title을 형식에 맞게 작성했나요(e.g. TOT-123 : [TYPE])
네
> 2. Reviewers가 명확하게 지정됐나요?
네
> 3. Assignees가 명확하게 지정됐나요?
네

## 📝 작업 내용
장소 공통정보 조회 API 구현


### 스크린샷


## 💬 리뷰 요구사항
Postman에서 요청을 보낼 때, 가끔씩 성공적으로 응답을 받기 위해서 여러 번의 요청을 보내야 하는 상황이 발생합니다. 어떨 때는 한번에 성공적으로 응답이 오고, 어떨 때는 send를 네 다섯번 눌러야 성공적으로 응답이 옵니다. 그래서  RetryTemplate를 이용하여 외부 API 호출 코드를 수정했는데, 여전히 여러 번의 요청을 보내야 성공적인 응답이 올 때가 있습니다.
외부 API 호출 후, 응답을 파싱하는 과정에서 문제가 있는 것 같은데, 이 부분은 좀 더 살펴봐야 할 것 같습니다!

## 참고자료

