### PR TITLE
TOT-54 : [FEAT] 계획 저장 API 구현

### DIFF
--- a/backend/src/main/java/com/triportreat/backend/common/response/FailMessage.java
+++ b/backend/src/main/java/com/triportreat/backend/common/response/FailMessage.java
@@ -8,9 +8,11 @@ public enum FailMessage {
     UNKNOWN_ERROR("알 수 없는 오류가 발생하였습니다."),
     REGION_NOT_FOUND("지역 정보가 존재하지 않습니다!"),
     RECOMMENDED_PLACE_EMPTY("추천 장소 정보가 존재하지 않습니다!"),
-    PLACE_NOT_FOUND("장소 정보가 존재하지 않습니다: "),
     API_CALL_FAILED("외부 API 호출에 실패하였습니다."),
-    API_RESPONSE_PARSE_FAILED("외부 API 응답 처리에 실패하였습니다.");
+    API_RESPONSE_PARSE_FAILED("외부 API 응답 처리에 실패하였습니다."),
+    USER_NOT_FOUND("사용자가 존재하지 않습니다!"),
+    PLACE_NOT_FOUND("장소가 존재하지 않습니다!"),
+    VALIDATION_FAILED("유효성 검증에 실패하였습니다!");
 
     private final String message;
 

--- a/backend/src/main/java/com/triportreat/backend/common/response/SuccessMessage.java
+++ b/backend/src/main/java/com/triportreat/backend/common/response/SuccessMessage.java
@@ -4,7 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum SuccessMessage {
-        GET_SUCCESS("조회에 성공하였습니다.");
+        GET_SUCCESS("조회에 성공하였습니다."),
+        POST_SUCCESS("계획 저장에 성공하였습니다.");
 
         private final String message;
 

--- a/backend/src/main/java/com/triportreat/backend/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/controller/PlanController.java
@@ -20,6 +20,7 @@ public class PlanController {
 
     @PostMapping("/plans")
     public ResponseEntity<?> createPlan(@RequestBody @Valid PlanCreateRequestDto planCreateRequestDto) {
+        planCreateRequestDto.setUserId(1L); // TODO 로그인 기능 구현 완료시 수정 필요
         planService.createPlan(planCreateRequestDto);
         return ResponseEntity.ok().body(ResponseResult.success(POST_SUCCESS.getMessage(), null));
     }

--- a/backend/src/main/java/com/triportreat/backend/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/controller/PlanController.java
@@ -1,0 +1,27 @@
+package com.triportreat.backend.plan.controller;
+
+import static com.triportreat.backend.common.response.SuccessMessage.POST_SUCCESS;
+
+import com.triportreat.backend.common.response.ResponseResult;
+import com.triportreat.backend.plan.domain.PlanCreateRequestDto;
+import com.triportreat.backend.plan.service.PlanService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class PlanController {
+
+    private final PlanService planService;
+
+    @PostMapping("/plans")
+    public ResponseEntity<?> createPlan(@RequestBody @Valid PlanCreateRequestDto planCreateRequestDto) {
+        planService.createPlan(planCreateRequestDto);
+        return ResponseEntity.ok().body(ResponseResult.success(POST_SUCCESS.getMessage(), null));
+    }
+
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/domain/PlanCreateRequestDto.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/domain/PlanCreateRequestDto.java
@@ -1,0 +1,35 @@
+package com.triportreat.backend.plan.domain;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PlanCreateRequestDto {
+
+    @NotEmpty(message = "제목은 필수 입력값입니다!")
+    private String title;
+
+    @NotNull(message = "여행 시작날짜는 필수 입력값입니다!")
+    private LocalDate startDate;
+
+    @NotNull(message = "여행 종료날짜는 필수 입력값입니다!")
+    private LocalDate endDate;
+
+    @NotNull(message = "사용자아이디는 필수 입력값입니다!")
+    private Long userId;
+
+    @Valid
+    @Size(min = 1, message = "스케쥴은 최소 하루는 있어야 합니다!")
+    private List<ScheduleCreateRequestDto> schedules = new ArrayList<>();
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/domain/PlanCreateRequestDto.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/domain/PlanCreateRequestDto.java
@@ -26,7 +26,6 @@ public class PlanCreateRequestDto {
     @NotNull(message = "여행 종료날짜는 필수 입력값입니다!")
     private LocalDate endDate;
 
-    @NotNull(message = "사용자아이디는 필수 입력값입니다!")
     private Long userId;
 
     @Builder.Default

--- a/backend/src/main/java/com/triportreat/backend/plan/domain/PlanCreateRequestDto.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/domain/PlanCreateRequestDto.java
@@ -29,6 +29,7 @@ public class PlanCreateRequestDto {
     @NotNull(message = "사용자아이디는 필수 입력값입니다!")
     private Long userId;
 
+    @Builder.Default
     @Valid
     @Size(min = 1, message = "스케쥴은 최소 하루는 있어야 합니다!")
     private List<ScheduleCreateRequestDto> schedules = new ArrayList<>();

--- a/backend/src/main/java/com/triportreat/backend/plan/domain/ScheduleCreateRequestDto.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/domain/ScheduleCreateRequestDto.java
@@ -24,6 +24,7 @@ public class ScheduleCreateRequestDto {
     @NotNull(message = "스케쥴의 날짜는 필수 입력값입니다!")
     private LocalDate date;
 
+    @Builder.Default
     @Valid
     @Size(min = 1, message = "방문장소는 최소 1곳입니다!")
     private List<SchedulePlaceCreateRequestDto> schedulePlaces = new ArrayList<>();

--- a/backend/src/main/java/com/triportreat/backend/plan/domain/ScheduleCreateRequestDto.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/domain/ScheduleCreateRequestDto.java
@@ -1,0 +1,30 @@
+package com.triportreat.backend.plan.domain;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class ScheduleCreateRequestDto {
+
+    @NotNull(message = "스케쥴의 날짜는 필수 입력값입니다!")
+    private LocalDate date;
+
+    @Valid
+    @Size(min = 1, message = "방문장소는 최소 1곳입니다!")
+    private List<SchedulePlaceCreateRequestDto> schedulePlaces = new ArrayList<>();
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/domain/SchedulePlaceCreateRequestDto.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/domain/SchedulePlaceCreateRequestDto.java
@@ -1,0 +1,33 @@
+package com.triportreat.backend.plan.domain;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class SchedulePlaceCreateRequestDto {
+
+    @NotNull(message = "장소아이디는 필수 입력값입니다!")
+    private Long placeId;
+
+    @Size(max = 65535, message = "메모의 최대길이는 65535자입니다!")
+    private String memo;
+
+    @NotNull(message = "방문순서는 필수 입력값입니다!")
+    @Min(value = 1, message = "순서는 최소 1부터입니다!")
+    private Integer visitOrder;
+
+    @Min(value = 0, message = "경비는 최소 0원부터입니다!")
+    private Long expense;
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/entity/Plan.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/entity/Plan.java
@@ -52,4 +52,13 @@ public class Plan extends BaseTimeEntity {
 
     private String code;
 
+    public static Plan toEntity(PlanCreateRequestDto planCreateRequestDto, User user, String code) {
+        return Plan.builder()
+                .user(user)
+                .title(planCreateRequestDto.getTitle())
+                .startDate(planCreateRequestDto.getStartDate())
+                .endDate(planCreateRequestDto.getEndDate())
+                .code(code)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/triportreat/backend/plan/entity/Plan.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/entity/Plan.java
@@ -1,7 +1,9 @@
 package com.triportreat.backend.plan.entity;
 
 import com.triportreat.backend.common.BaseTimeEntity;
+import com.triportreat.backend.plan.domain.PlanCreateRequestDto;
 import com.triportreat.backend.user.entity.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,17 +12,22 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
+@ToString(exclude = "schedules")
 public class Plan extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,6 +36,10 @@ public class Plan extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Schedule> schedules = new ArrayList<>();
 
     @Column(length = 20, nullable = false)
     private String title;

--- a/backend/src/main/java/com/triportreat/backend/plan/entity/Schedule.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/entity/Schedule.java
@@ -43,4 +43,10 @@ public class Schedule extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDate visitDate;
 
+    public static Schedule toEntity(ScheduleCreateRequestDto scheduleCreateRequestDto, Plan plan) {
+        return Schedule.builder()
+                .plan(plan)
+                .visitDate(scheduleCreateRequestDto.getDate())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/triportreat/backend/plan/entity/Schedule.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/entity/Schedule.java
@@ -1,6 +1,8 @@
 package com.triportreat.backend.plan.entity;
 
 import com.triportreat.backend.common.BaseTimeEntity;
+import com.triportreat.backend.plan.domain.ScheduleCreateRequestDto;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -9,17 +11,22 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
+@ToString(exclude = "schedulePlaces")
 public class Schedule extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,6 +35,10 @@ public class Schedule extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
     private Plan plan;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SchedulePlace> schedulePlaces = new ArrayList<>();
 
     @Column(nullable = false)
     private LocalDate visitDate;

--- a/backend/src/main/java/com/triportreat/backend/plan/entity/SchedulePlace.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/entity/SchedulePlace.java
@@ -46,4 +46,15 @@ public class SchedulePlace extends BaseTimeEntity {
     @Column(length = 65535)
     private String memo;
 
+    public static SchedulePlace toEntity(SchedulePlaceCreateRequestDto schedulePlaceCreateRequestDto,
+                                         Schedule schedule,
+                                         Place place) {
+        return SchedulePlace.builder()
+                .schedule(schedule)
+                .place(place)
+                .visitOrder(schedulePlaceCreateRequestDto.getVisitOrder())
+                .expense(schedulePlaceCreateRequestDto.getExpense())
+                .memo(schedulePlaceCreateRequestDto.getMemo())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/triportreat/backend/plan/entity/SchedulePlace.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/entity/SchedulePlace.java
@@ -2,6 +2,7 @@ package com.triportreat.backend.plan.entity;
 
 import com.triportreat.backend.common.BaseTimeEntity;
 import com.triportreat.backend.place.entity.Place;
+import com.triportreat.backend.plan.domain.SchedulePlaceCreateRequestDto;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,12 +15,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @Getter
+@ToString
 public class SchedulePlace extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/triportreat/backend/plan/error/exception/PlaceNotFoundException.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/error/exception/PlaceNotFoundException.java
@@ -9,7 +9,7 @@ public class PlaceNotFoundException extends AbstractException {
 
     @Override
     public HttpStatus getStatus() {
-        return HttpStatus.NOT_FOUND;
+        return HttpStatus.INTERNAL_SERVER_ERROR;
     }
 
     @Override

--- a/backend/src/main/java/com/triportreat/backend/plan/error/exception/PlaceNotFoundException.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/error/exception/PlaceNotFoundException.java
@@ -1,0 +1,19 @@
+package com.triportreat.backend.plan.error.exception;
+
+import static com.triportreat.backend.common.response.FailMessage.PLACE_NOT_FOUND;
+
+import com.triportreat.backend.common.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class PlaceNotFoundException extends AbstractException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+
+    @Override
+    public String getMessage() {
+        return PLACE_NOT_FOUND.getMessage();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/error/exception/UserNotFoundException.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/error/exception/UserNotFoundException.java
@@ -9,7 +9,7 @@ public class UserNotFoundException extends AbstractException {
 
     @Override
     public HttpStatus getStatus() {
-        return HttpStatus.NOT_FOUND;
+        return HttpStatus.INTERNAL_SERVER_ERROR;
     }
 
     @Override

--- a/backend/src/main/java/com/triportreat/backend/plan/error/exception/UserNotFoundException.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/error/exception/UserNotFoundException.java
@@ -1,0 +1,19 @@
+package com.triportreat.backend.plan.error.exception;
+
+import static com.triportreat.backend.common.response.FailMessage.USER_NOT_FOUND;
+
+import com.triportreat.backend.common.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class UserNotFoundException extends AbstractException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+
+    @Override
+    public String getMessage() {
+        return USER_NOT_FOUND.getMessage();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/error/handler/PlanExceptionHandler.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/error/handler/PlanExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.triportreat.backend.plan.error.handler;
+
+import static com.triportreat.backend.common.response.FailMessage.VALIDATION_FAILED;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import com.triportreat.backend.common.AbstractException;
+import com.triportreat.backend.common.response.ResponseResult;
+import com.triportreat.backend.plan.controller.PlanController;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackageClasses = PlanController.class)
+public class PlanExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<?> MethodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
+        Map<String, String> errors = e.getBindingResult().getFieldErrors()
+                .stream()
+                .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage));
+        return ResponseEntity.ok().body(ResponseResult.fail(VALIDATION_FAILED.getMessage(), BAD_REQUEST, errors));
+    }
+
+    @ExceptionHandler(AbstractException.class)
+    protected ResponseEntity<?> usernameNotFoundExceptionHandler(AbstractException e) {
+        return ResponseEntity.ok().body(ResponseResult.fail(e.getMessage(), e.getStatus(), null));
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/error/handler/PlanExceptionHandler.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/error/handler/PlanExceptionHandler.java
@@ -26,7 +26,7 @@ public class PlanExceptionHandler {
     }
 
     @ExceptionHandler(AbstractException.class)
-    protected ResponseEntity<?> usernameNotFoundExceptionHandler(AbstractException e) {
+    protected ResponseEntity<?> planAbstractExceptionHandler(AbstractException e) {
         return ResponseEntity.ok().body(ResponseResult.fail(e.getMessage(), e.getStatus(), null));
     }
 }

--- a/backend/src/main/java/com/triportreat/backend/plan/repository/PlanRepository.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/repository/PlanRepository.java
@@ -1,0 +1,8 @@
+package com.triportreat.backend.plan.repository;
+
+import com.triportreat.backend.plan.entity.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/repository/SchedulePlaceRepository.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/repository/SchedulePlaceRepository.java
@@ -1,0 +1,8 @@
+package com.triportreat.backend.plan.repository;
+
+import com.triportreat.backend.plan.entity.SchedulePlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SchedulePlaceRepository extends JpaRepository<SchedulePlace, Long> {
+
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/repository/ScheduleRepository.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/repository/ScheduleRepository.java
@@ -1,0 +1,8 @@
+package com.triportreat.backend.plan.repository;
+
+import com.triportreat.backend.plan.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/service/PlanService.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/service/PlanService.java
@@ -1,0 +1,7 @@
+package com.triportreat.backend.plan.service;
+
+import com.triportreat.backend.plan.domain.PlanCreateRequestDto;
+
+public interface PlanService {
+    void createPlan(PlanCreateRequestDto planCreateRequestDto);
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/service/impl/PlanServiceImpl.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/service/impl/PlanServiceImpl.java
@@ -1,0 +1,62 @@
+package com.triportreat.backend.plan.service.impl;
+
+import com.triportreat.backend.place.entity.Place;
+import com.triportreat.backend.place.repository.PlaceRepository;
+import com.triportreat.backend.plan.domain.PlanCreateRequestDto;
+import com.triportreat.backend.plan.domain.ScheduleCreateRequestDto;
+import com.triportreat.backend.plan.domain.SchedulePlaceCreateRequestDto;
+import com.triportreat.backend.plan.entity.Plan;
+import com.triportreat.backend.plan.entity.Schedule;
+import com.triportreat.backend.plan.entity.SchedulePlace;
+import com.triportreat.backend.plan.repository.PlanRepository;
+import com.triportreat.backend.plan.repository.SchedulePlaceRepository;
+import com.triportreat.backend.plan.repository.ScheduleRepository;
+import com.triportreat.backend.plan.service.PlanService;
+import com.triportreat.backend.user.entity.User;
+import com.triportreat.backend.user.repository.UserRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlanServiceImpl implements PlanService {
+
+    private final PlanRepository planRepository;
+    private final UserRepository userRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final PlaceRepository placeRepository;
+    private final SchedulePlaceRepository schedulePlaceRepository;
+
+    @Transactional
+    @Override
+    public void createPlan(PlanCreateRequestDto planCreateRequestDto) {
+        User user = userRepository.findById(planCreateRequestDto.getUserId())
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 사용자입니다!"));  // TODO 사용자 존재하지 않음 예외 생성
+
+        String code = "";  // TODO Plan Code
+        Plan plan = Plan.toEntity(planCreateRequestDto, user, code);
+        planRepository.save(plan);
+
+        createSchedules(planCreateRequestDto.getSchedules(), plan);
+    }
+
+    private void createSchedules(List<ScheduleCreateRequestDto> schedulesRequests, Plan plan) {
+        schedulesRequests.forEach(s -> {
+            Schedule schedule = Schedule.toEntity(s, plan);
+            scheduleRepository.save(schedule);
+            createSchedulePlaces(s.getSchedulePlaces(), schedule);
+        });
+    }
+
+    private void createSchedulePlaces(List<SchedulePlaceCreateRequestDto> schedulePlaceRequests, Schedule schedule) {
+        schedulePlaceRequests.forEach(sp -> {
+            Place place = placeRepository.findById(sp.getPlaceId())
+                    .orElseThrow(() -> new RuntimeException("존재하지 않는 장소입니다!"));  // TODO 장소 존재하지 않음 예외 생성
+            SchedulePlace schedulePlace = SchedulePlace.toEntity(sp, schedule, place);
+            schedulePlaceRepository.save(schedulePlace);
+        });
+    }
+
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/service/impl/PlanServiceImpl.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/service/impl/PlanServiceImpl.java
@@ -26,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PlanServiceImpl implements PlanService {
 
+    private static final String url = "https://api.triportreat.site/plans/";
+
     private final PlanRepository planRepository;
     private final UserRepository userRepository;
     private final ScheduleRepository scheduleRepository;
@@ -38,7 +40,7 @@ public class PlanServiceImpl implements PlanService {
         User user = userRepository.findById(planCreateRequestDto.getUserId())
                 .orElseThrow(UserNotFoundException::new);
 
-        Plan plan = Plan.toEntity(planCreateRequestDto, user, createPlanCode());
+        Plan plan = Plan.toEntity(planCreateRequestDto, user, url + createPlanCode());
         planRepository.save(plan);
 
         createSchedules(planCreateRequestDto.getSchedules(), plan);

--- a/backend/src/main/java/com/triportreat/backend/plan/service/impl/PlanServiceImpl.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/service/impl/PlanServiceImpl.java
@@ -26,8 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class PlanServiceImpl implements PlanService {
 
-    private static final String url = "https://api.triportreat.site/plans/";
-
     private final PlanRepository planRepository;
     private final UserRepository userRepository;
     private final ScheduleRepository scheduleRepository;
@@ -40,7 +38,7 @@ public class PlanServiceImpl implements PlanService {
         User user = userRepository.findById(planCreateRequestDto.getUserId())
                 .orElseThrow(UserNotFoundException::new);
 
-        Plan plan = Plan.toEntity(planCreateRequestDto, user, url + createPlanCode());
+        Plan plan = Plan.toEntity(planCreateRequestDto, user, createPlanCode());
         planRepository.save(plan);
 
         createSchedules(planCreateRequestDto.getSchedules(), plan);

--- a/backend/src/main/java/com/triportreat/backend/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/triportreat/backend/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.triportreat.backend.user.repository;
+
+import com.triportreat.backend.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/backend/src/test/java/com/triportreat/backend/plan/controller/PlanControllerTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/controller/PlanControllerTest.java
@@ -1,0 +1,118 @@
+package com.triportreat.backend.plan.controller;
+
+import static com.triportreat.backend.common.response.FailMessage.VALIDATION_FAILED;
+import static com.triportreat.backend.common.response.SuccessMessage.POST_SUCCESS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.triportreat.backend.plan.domain.PlanCreateRequestDto;
+import com.triportreat.backend.plan.domain.ScheduleCreateRequestDto;
+import com.triportreat.backend.plan.domain.SchedulePlaceCreateRequestDto;
+import com.triportreat.backend.plan.service.PlanService;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = PlanController.class)
+@AutoConfigureMockMvc
+class PlanControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    PlanService planService;
+
+    private PlanCreateRequestDto createPlanRequestDtoBeforeTest() {
+        List<SchedulePlaceCreateRequestDto> schedulePlaceRequests1 = List.of(
+                SchedulePlaceCreateRequestDto.builder()
+                        .placeId(1L)
+                        .visitOrder(1)
+                        .memo("memo")
+                        .expense(1000L)
+                        .build(),
+                SchedulePlaceCreateRequestDto.builder().placeId(1L)
+                        .visitOrder(2)
+                        .memo("memo")
+                        .expense(2000L)
+                        .build());
+
+        List<SchedulePlaceCreateRequestDto> schedulePlaceRequests2 = List.of(
+                SchedulePlaceCreateRequestDto.builder()
+                        .placeId(3L)
+                        .visitOrder(3)
+                        .memo("memo")
+                        .expense(3000L)
+                        .build(),
+                SchedulePlaceCreateRequestDto.builder().placeId(1L)
+                        .visitOrder(4)
+                        .memo("memo")
+                        .expense(4000L)
+                        .build());
+
+        List<ScheduleCreateRequestDto> scheduleRequests = List.of(
+                ScheduleCreateRequestDto.builder().date(LocalDate.now()).schedulePlaces(schedulePlaceRequests1).build(),
+                ScheduleCreateRequestDto.builder().date(LocalDate.now().plusDays(1)).schedulePlaces(schedulePlaceRequests2).build());
+
+        return PlanCreateRequestDto.builder()
+                .userId(1L)
+                .title("title")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(1))
+                .schedules(scheduleRequests)
+                .build();
+    }
+
+    @Test
+    @DisplayName("계획저장 컨트롤러 메소드 테스트")
+    void createPlan() throws Exception {
+        // given
+        PlanCreateRequestDto planCreateRequestDto = createPlanRequestDtoBeforeTest();
+
+        // when
+        doNothing().when(planService).createPlan(planCreateRequestDto);
+
+        // then
+        mockMvc.perform(post("/plans")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().registerModule(new JavaTimeModule()).writeValueAsString(planCreateRequestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.message", equalTo(POST_SUCCESS.getMessage())))
+                .andExpect(jsonPath("$.result", equalTo(true)))
+                .andExpect(jsonPath("$.data", equalTo(null)));
+    }
+
+    @Test()
+    @DisplayName("계획저장 컨트롤러 메소드 유효성 검증 실패 예외발생테스트")
+    void createPlan_UserNotFoundException() throws Exception {
+        // given
+        PlanCreateRequestDto planCreateRequestDto = createPlanRequestDtoBeforeTest();
+        planCreateRequestDto.setTitle("");
+
+        // when
+        doNothing().when(planService).createPlan(planCreateRequestDto);
+
+        // then
+        mockMvc.perform(post("/plans")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(new ObjectMapper().registerModule(new JavaTimeModule()).writeValueAsString(planCreateRequestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(400)))
+                .andExpect(jsonPath("$.message", equalTo(VALIDATION_FAILED.getMessage())))
+                .andExpect(jsonPath("$.result", equalTo(false)));
+    }
+}

--- a/backend/src/test/java/com/triportreat/backend/plan/repository/PlanRepositoryTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/repository/PlanRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.triportreat.backend.plan.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.triportreat.backend.plan.entity.Plan;
+import com.triportreat.backend.plan.entity.Schedule;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class PlanRepositoryTest {
+
+    @Autowired
+    PlanRepository planRepository;
+
+    @Autowired
+    ScheduleRepository scheduleRepository;
+
+    @Test
+    @DisplayName("계획엔티티 save() 테스트")
+    void savePlan() {
+        // given
+        LocalDate today = LocalDate.now();
+        LocalDate nextDay = today.plusDays(1);
+
+        Plan plan = Plan.builder()
+                .title("title")
+                .startDate(today)
+                .endDate(nextDay)
+                .build();
+        planRepository.save(plan);
+
+        Schedule schedule1 = Schedule.builder()
+                .plan(plan)
+                .visitDate(today)
+                .build();
+        scheduleRepository.save(schedule1);
+
+        Schedule schedule2 = Schedule.builder()
+                .plan(plan)
+                .visitDate(nextDay)
+                .build();
+        scheduleRepository.save(schedule2);
+
+        // when
+        List<Schedule> schedules = scheduleRepository.findAll();
+
+        // then
+        Schedule savedSchedule1 = schedules.get(0);
+        Schedule savedSchedule2 = schedules.get(1);
+
+        assertThat(schedules.size()).isEqualTo(2);
+        assertThat(savedSchedule1.getVisitDate()).isEqualTo(today);
+        assertThat(savedSchedule1.getPlan().getTitle()).isEqualTo("title");
+        assertThat(savedSchedule1.getPlan().getStartDate()).isEqualTo(today);
+        assertThat(savedSchedule1.getPlan().getEndDate()).isEqualTo(nextDay);
+        assertThat(savedSchedule2.getVisitDate()).isEqualTo(nextDay);
+        assertThat(savedSchedule2.getPlan().getTitle()).isEqualTo("title");
+        assertThat(savedSchedule2.getPlan().getStartDate()).isEqualTo(today);
+        assertThat(savedSchedule2.getPlan().getEndDate()).isEqualTo(nextDay);
+    }
+}

--- a/backend/src/test/java/com/triportreat/backend/plan/repository/PlanRepositoryTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/repository/PlanRepositoryTest.java
@@ -55,12 +55,7 @@ class PlanRepositoryTest {
 
         assertThat(schedules.size()).isEqualTo(2);
         assertThat(savedSchedule1.getVisitDate()).isEqualTo(today);
-        assertThat(savedSchedule1.getPlan().getTitle()).isEqualTo("title");
-        assertThat(savedSchedule1.getPlan().getStartDate()).isEqualTo(today);
-        assertThat(savedSchedule1.getPlan().getEndDate()).isEqualTo(nextDay);
-        assertThat(savedSchedule2.getVisitDate()).isEqualTo(nextDay);
-        assertThat(savedSchedule2.getPlan().getTitle()).isEqualTo("title");
-        assertThat(savedSchedule2.getPlan().getStartDate()).isEqualTo(today);
-        assertThat(savedSchedule2.getPlan().getEndDate()).isEqualTo(nextDay);
+        assertThat(savedSchedule1.getPlan()).usingRecursiveComparison().isEqualTo(plan);
+        assertThat(savedSchedule2.getPlan()).usingRecursiveComparison().isEqualTo(plan);
     }
 }

--- a/backend/src/test/java/com/triportreat/backend/plan/service/PlanServiceTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/service/PlanServiceTest.java
@@ -1,0 +1,135 @@
+package com.triportreat.backend.plan.service;
+
+import static com.triportreat.backend.common.response.FailMessage.PLACE_NOT_FOUND;
+import static com.triportreat.backend.common.response.FailMessage.USER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import com.triportreat.backend.place.entity.Place;
+import com.triportreat.backend.place.repository.PlaceRepository;
+import com.triportreat.backend.plan.domain.PlanCreateRequestDto;
+import com.triportreat.backend.plan.domain.SchedulePlaceCreateRequestDto;
+import com.triportreat.backend.plan.domain.ScheduleCreateRequestDto;
+import com.triportreat.backend.plan.entity.Plan;
+import com.triportreat.backend.plan.entity.Schedule;
+import com.triportreat.backend.plan.entity.SchedulePlace;
+import com.triportreat.backend.plan.error.exception.PlaceNotFoundException;
+import com.triportreat.backend.plan.error.exception.UserNotFoundException;
+import com.triportreat.backend.plan.repository.PlanRepository;
+import com.triportreat.backend.plan.repository.SchedulePlaceRepository;
+import com.triportreat.backend.plan.repository.ScheduleRepository;
+import com.triportreat.backend.user.entity.User;
+import com.triportreat.backend.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+class PlanServiceTest {
+
+    @Autowired
+    PlanService planService;
+
+    @MockBean
+    PlanRepository planRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @MockBean
+    ScheduleRepository scheduleRepository;
+
+    @MockBean
+    PlaceRepository placeRepository;
+
+    @MockBean
+    SchedulePlaceRepository schedulePlaceRepository;
+
+    private PlanCreateRequestDto createPlanRequestDtoBeforeTest() {
+        List<SchedulePlaceCreateRequestDto> schedulePlaceRequests1 = List.of(
+                SchedulePlaceCreateRequestDto.builder().placeId(1L).build(),
+                SchedulePlaceCreateRequestDto.builder().placeId(2L).build());
+
+        List<SchedulePlaceCreateRequestDto> schedulePlaceRequests2 = List.of(
+                SchedulePlaceCreateRequestDto.builder().placeId(3L).build(),
+                SchedulePlaceCreateRequestDto.builder().placeId(4L).build());
+
+        List<ScheduleCreateRequestDto> scheduleRequests = List.of(
+                ScheduleCreateRequestDto.builder().date(LocalDate.now()).schedulePlaces(schedulePlaceRequests1).build(),
+                ScheduleCreateRequestDto.builder().date(LocalDate.now().plusDays(1)).schedulePlaces(schedulePlaceRequests2).build());
+
+        return PlanCreateRequestDto.builder()
+                .userId(1L)
+                .schedules(scheduleRequests)
+                .build();
+    }
+
+    @Test
+    @DisplayName("계획 저장 서비스 메소드 테스트")
+    void createPlan() {
+        // given
+        PlanCreateRequestDto planCreateRequestDto = createPlanRequestDtoBeforeTest();
+
+        User user = User.builder().id(planCreateRequestDto.getUserId()).build();
+        Plan plan = Plan.builder().id(1L).title(planCreateRequestDto.getTitle()).build();
+
+        // when
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(planRepository.save(any(Plan.class))).thenReturn(plan);
+        when(placeRepository.findById(anyLong())).thenReturn(Optional.of(Place.builder().id(1L).build()));
+        when(placeRepository.findById(anyLong())).thenReturn(Optional.of(Place.builder().id(2L).build()));
+        when(placeRepository.findById(anyLong())).thenReturn(Optional.of(Place.builder().id(3L).build()));
+        when(placeRepository.findById(anyLong())).thenReturn(Optional.of(Place.builder().id(4L).build()));
+
+        planService.createPlan(planCreateRequestDto);
+
+        // then
+        verify(schedulePlaceRepository, times(4)).save(any(SchedulePlace.class));
+        verify(scheduleRepository, times(2)).save(any(Schedule.class));
+        verify(planRepository, times(1)).save(any(Plan.class));
+    }
+
+    @Test
+    @DisplayName("계획저장할 때 사용자가 존재하지 않을시 예외발생")
+    void createPlan_UserNotFoundException() {
+        // given
+        PlanCreateRequestDto planCreateRequestDto = createPlanRequestDtoBeforeTest();
+
+        // when
+        when(userRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> planService.createPlan(planCreateRequestDto))
+                .isInstanceOf(UserNotFoundException.class)
+                .hasMessage(USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("계획저장할 때 선택한 장소가 존재하지 않을시 예외발생")
+    void createPlan_PlaceNotFoundException() {
+        // given
+        PlanCreateRequestDto planCreateRequestDto = createPlanRequestDtoBeforeTest();
+
+        User user = User.builder().id(planCreateRequestDto.getUserId()).build();
+        Plan plan = Plan.builder().id(1L).title(planCreateRequestDto.getTitle()).build();
+
+        // when
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(user));
+        when(planRepository.save(any(Plan.class))).thenReturn(plan);
+        when(placeRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> planService.createPlan(planCreateRequestDto))
+                .isInstanceOf(PlaceNotFoundException.class)
+                .hasMessage(PLACE_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## PR전 체크리스트
> 1. PR 및 Commit title을 형식에 맞게 작성했나요(e.g. TOT-123 : [TYPE]) O
> 2. Reviewers가 명확하게 지정됐나요? O
> 3. Assignees가 명확하게 지정됐나요? O


## 📝 작업 내용
- 계획 저장 API 구현
- 계획 공유 코드는 'URL + code(uuid 문자열)'로 생성하여 저장
- 양방향 연관관계 및 영속성 전이, 고아 객체 제거 옵션 적용
- 계획 저장 요청 Dto에 validation 적용

- 나중에 공통적인 ExceptionHandler 따로 정리 필요

### 스크린샷
<img width="777" alt="스크린샷 2024-03-05 오후 3 07 21" src="https://github.com/trip-or-treat/trip-or-treat/assets/93666531/df188b97-8644-4588-92cf-a0ec7bde61f4">

## 💬 리뷰 요구사항
- validation이 요구사항에 맞게 적용이 되었는지?
- 컬렉션으로 이루어진 Dto의 경우 에러 출력 방식의 변경이 필요한지? 스크린샷 참고(ex : "schedules[0].schedulePlaces[0].expense": "경비는 최소 0원부터입니다!")
- 계획 공유 코드 저장 전략을 어떻게 세우는게 나을 것인지? (uuid 문자열 길이는 적당한가?, URL + 코드로 저장 vs 코드만 저장 등등)

## 참고자료
[컬렉션 필드 초기화 이유](https://www.inflearn.com/questions/258175/%ED%95%84%EB%93%9C%EC%97%90-%EC%9E%88%EB%8A%94-%EC%BB%AC%EB%A0%89%EC%85%98%EC%9D%84-%EC%B4%88%EA%B8%B0%ED%99%94-%EC%8B%9C%ED%82%A4%EB%8A%94-%EC%9D%B4%EC%9C%A0%EA%B0%80-%EB%AD%94%EA%B0%80%EC%9A%94)
[스프링 validation 어노테이션 모음](https://thinkground.studio/2021/08/21/spring-boot-%EC%9C%A0%ED%9A%A8%EC%84%B1-%EA%B2%80%EC%82%AC-validation-%EA%B4%80%EB%A0%A8-%EC%96%B4%EB%85%B8%ED%85%8C%EC%9D%B4%EC%85%98/)

