### PR TITLE
TOT-91 : [FIX] 지역정보조회 API 수정

### DIFF
--- a/backend/src/main/java/com/triportreat/backend/region/domain/RegionDetailResponseDto.java
+++ b/backend/src/main/java/com/triportreat/backend/region/domain/RegionDetailResponseDto.java
@@ -16,7 +16,7 @@ import lombok.*;
 public class RegionDetailResponseDto {
     private Long id;
     private String name;
-    private String imageOrigin;
+    private String imageThumbnail;
     private String overview;
     private Double latitude;
     private Double longitude;
@@ -26,7 +26,7 @@ public class RegionDetailResponseDto {
         return RegionDetailResponseDto.builder()
                 .id(region.getId())
                 .name(region.getName())
-                .imageOrigin(region.getImageOrigin())
+                .imageThumbnail(region.getImageThumbnail())
                 .overview(region.getOverview())
                 .latitude(region.getLatitude())
                 .longitude(region.getLongitude())

--- a/backend/src/main/java/com/triportreat/backend/region/domain/RegionResponseDto.java
+++ b/backend/src/main/java/com/triportreat/backend/region/domain/RegionResponseDto.java
@@ -12,7 +12,6 @@ import lombok.*;
 public class RegionResponseDto {
     private Long id;
     private String name;
-    private String imageOrigin;
     private String imageThumbnail;
     private Double latitude;
     private Double longitude;
@@ -21,7 +20,6 @@ public class RegionResponseDto {
         return RegionResponseDto.builder()
                 .id(region.getId())
                 .name(region.getName())
-                .imageOrigin(region.getImageOrigin())
                 .imageThumbnail(region.getImageThumbnail())
                 .latitude(region.getLatitude())
                 .longitude(region.getLongitude())

--- a/backend/src/test/java/com/triportreat/backend/region/service/RegionServiceTest.java
+++ b/backend/src/test/java/com/triportreat/backend/region/service/RegionServiceTest.java
@@ -68,7 +68,7 @@ class RegionServiceTest {
         Region region = Region.builder()
                 .id(regionId)
                 .name("지역이름")
-                .imageOrigin("이미지저장경로")
+                .imageThumbnail("이미지저장경로")
                 .overview("지역정보")
                 .latitude(1.1)
                 .longitude(2.2)
@@ -108,7 +108,7 @@ class RegionServiceTest {
         // then
         assertThat(regionDetail.getId()).isEqualTo(regionId);
         assertThat(regionDetail.getName()).isEqualTo("지역이름");
-        assertThat(regionDetail.getImageOrigin()).isEqualTo("이미지저장경로");
+        assertThat(regionDetail.getImageThumbnail()).isEqualTo("이미지저장경로");
         assertThat(regionDetail.getOverview()).isEqualTo("지역정보");
         assertThat(regionDetail.getLatitude()).isEqualTo(1.1);
         assertThat(regionDetail.getLongitude()).isEqualTo(2.2);


### PR DESCRIPTION
## PR전 체크리스트
> 1. PR 및 Commit title을 형식에 맞게 작성했나요(e.g. TOT-123 : [TYPE]) O
> 2. Reviewers가 명확하게 지정됐나요? O
> 3. Assignees가 명확하게 지정됐나요? O


## 📝 작업 내용
- 하나의 이미지(imageThumbnail필드)만 사용하겠다고 프론트분들이 말씀하셔서 조금 수정해두었습니다.
- 지역정보관련 응답Dto의 필드 변경
    - `RegionResponseDto`의 imageOrigin 필드값 삭제.
    - `RegionDetailResponseDto`의 imageOrigin필드를 imageThumbnail로 바꾸고 Region의 imageThumbnail을 가져오도록 변경.
- 필드값 변경에 따른 테스트 코드 수정.


### 스크린샷

## 💬 리뷰 요구사항

## 참고자료
