### PR TITLE
TOT-92 : [FIX] 특정 지역별 장소목록 조회 API 동적쿼리 수정

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 application-local.yml
+spy.log
 
 ### STS ###
 .apt_generated

--- a/backend/src/main/java/com/triportreat/backend/place/domain/PlaceByRegionIdDto.java
+++ b/backend/src/main/java/com/triportreat/backend/place/domain/PlaceByRegionIdDto.java
@@ -15,10 +15,11 @@ public class PlaceByRegionIdDto {
     private Double latitude;
     private Double longitude;
     private Long contentTypeId;
+    private Long views;
 
     @QueryProjection
     public PlaceByRegionIdDto(Long id, String name, String imageThumbnail, String subCategoryName, Double latitude,
-                              Double longitude, Long contentTypeId) {
+                              Double longitude, Long contentTypeId, Long views) {
         this.id = id;
         this.name = name;
         this.imageThumbnail = imageThumbnail;
@@ -26,5 +27,6 @@ public class PlaceByRegionIdDto {
         this.latitude = latitude;
         this.longitude = longitude;
         this.contentTypeId = contentTypeId;
+        this.views = views;
     }
 }

--- a/backend/src/main/java/com/triportreat/backend/place/repository/impl/PlaceRepositoryImpl.java
+++ b/backend/src/main/java/com/triportreat/backend/place/repository/impl/PlaceRepositoryImpl.java
@@ -36,30 +36,25 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
                         subCategory.name,
                         place.latitude,
                         place.longitude,
-                        contentType.id))
+                        contentType.id,
+                        place.views))
                 .from(place)
                 .leftJoin(place.subCategory, subCategory)
                 .where(
                         region.id.eq(placeSearchCondition.getRegionId()),
                         contentTypeIdEquals(placeSearchCondition.getContentTypeId()),
-                        placeNameContains(placeSearchCondition.getKeyword()),
-                        subCategoryNameContains(placeSearchCondition.getKeyword())
+                        keywordContains(placeSearchCondition.getKeyword())
                 )
+                .orderBy(place.views.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
     }
 
-    public BooleanExpression placeNameContains(String keyword) {
+    public BooleanExpression keywordContains(String keyword) {
         if (hasText(keyword)) {
-            return place.name.contains(keyword);
-        }
-        return null;
-    }
-
-    public BooleanExpression subCategoryNameContains(String keyword) {
-        if (hasText(keyword)) {
-            return subCategory.name.contains(keyword);
+            return place.name.contains(keyword)
+                    .or(subCategory.name.contains(keyword));
         }
         return null;
     }

--- a/backend/src/test/java/com/triportreat/backend/place/repository/impl/PlaceRepositoryImplTest.java
+++ b/backend/src/test/java/com/triportreat/backend/place/repository/impl/PlaceRepositoryImplTest.java
@@ -1,6 +1,7 @@
 package com.triportreat.backend.place.repository.impl;
 
 import static com.triportreat.backend.place.entity.QContentType.contentType;
+import static com.triportreat.backend.place.entity.QPlace.place;
 import static com.triportreat.backend.place.entity.QSubCategory.subCategory;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -103,7 +104,7 @@ class PlaceRepositoryImplTest {
         placeSearchCondition.setKeyword(null);
 
         // when
-        BooleanExpression booleanExpression = placeRepositoryImpl.placeNameContains(placeSearchCondition.getKeyword());
+        BooleanExpression booleanExpression = placeRepositoryImpl.keywordContains(placeSearchCondition.getKeyword());
 
         // then
         assertThat(booleanExpression).isEqualTo(null);
@@ -117,11 +118,13 @@ class PlaceRepositoryImplTest {
         placeSearchCondition.setKeyword("키워드");
 
         // when
-        BooleanExpression booleanExpression = placeRepositoryImpl.subCategoryNameContains(
+        BooleanExpression booleanExpression = placeRepositoryImpl.keywordContains(
                 placeSearchCondition.getKeyword());
 
         // then
-        assertThat(booleanExpression).isEqualTo(subCategory.name.contains(placeSearchCondition.getKeyword()));
+        assertThat(booleanExpression).isEqualTo(
+                place.name.contains(placeSearchCondition.getKeyword())
+                        .or(subCategory.name.contains(placeSearchCondition.getKeyword())));
     }
 
     @Test


### PR DESCRIPTION
## PR전 체크리스트
> 1. PR 및 Commit title을 형식에 맞게 작성했나요(e.g. TOT-123 : [TYPE]) 네
> 2. Reviewers가 명확하게 지정됐나요? 네
> 3. Assignees가 명확하게 지정됐나요? 네


## 📝 작업 내용
- 키워드가 장소이름과 소분류이름 모두에 포함되는 데이터만 반환하던 로직을 둘 중 하나에라도 포함되어도 반환하도록 수정
- 조회수 순서로 정렬된 데이터를 반환하도록 수정
- 반환Dto에 조회수 필드 추가

### 스크린샷


## 💬 리뷰 요구사항


## 참고자료

