### PR TITLE
TOT-81 : [FEAT] 계획 상세정보 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/triportreat/backend/common/response/FailMessage.java
+++ b/backend/src/main/java/com/triportreat/backend/common/response/FailMessage.java
@@ -12,7 +12,8 @@ public enum FailMessage {
     API_RESPONSE_PARSE_FAILED("외부 API 응답 처리에 실패하였습니다."),
     USER_NOT_FOUND("사용자가 존재하지 않습니다!"),
     PLACE_NOT_FOUND("장소가 존재하지 않습니다!"),
-    VALIDATION_FAILED("유효성 검증에 실패하였습니다!");
+    VALIDATION_FAILED("유효성 검증에 실패하였습니다!"),
+    PLAN_NOT_FOUND("계획이 존재하지 않습니다!");
 
     private final String message;
 

--- a/backend/src/main/java/com/triportreat/backend/plan/controller/PlanController.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/controller/PlanController.java
@@ -1,5 +1,6 @@
 package com.triportreat.backend.plan.controller;
 
+import static com.triportreat.backend.common.response.SuccessMessage.GET_SUCCESS;
 import static com.triportreat.backend.common.response.SuccessMessage.POST_SUCCESS;
 
 import com.triportreat.backend.common.response.ResponseResult;
@@ -8,6 +9,8 @@ import com.triportreat.backend.plan.service.PlanService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,6 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 public class PlanController {
 
     private final PlanService planService;
+
+    @GetMapping("/plans/{id}")
+    public ResponseEntity<?> getPlanDetail(@PathVariable("id") Long id) {
+        return ResponseEntity.ok().body(ResponseResult.success(GET_SUCCESS.getMessage(), planService.getPlanDetail(id)));
+    }
 
     @PostMapping("/plans")
     public ResponseEntity<?> createPlan(@RequestBody @Valid PlanCreateRequestDto planCreateRequestDto) {

--- a/backend/src/main/java/com/triportreat/backend/plan/domain/PlanDetailResponseDto.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/domain/PlanDetailResponseDto.java
@@ -1,0 +1,35 @@
+package com.triportreat.backend.plan.domain;
+
+import com.triportreat.backend.plan.entity.Plan;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class PlanDetailResponseDto {
+    private Long planId;
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String code;
+
+    @Builder.Default
+    private List<ScheduleDetailResponseDto> schedules = new ArrayList<>();
+
+    public static PlanDetailResponseDto toDto(Plan plan, List<ScheduleDetailResponseDto> schedules) {
+        return PlanDetailResponseDto.builder()
+                .planId(plan.getId())
+                .title(plan.getTitle())
+                .startDate(plan.getStartDate())
+                .endDate(plan.getEndDate())
+                .code(plan.getCode())
+                .schedules(schedules)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/domain/ScheduleDetailResponseDto.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/domain/ScheduleDetailResponseDto.java
@@ -1,0 +1,34 @@
+package com.triportreat.backend.plan.domain;
+
+import com.triportreat.backend.plan.entity.Schedule;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ScheduleDetailResponseDto {
+    private Long scheduleId;
+    private LocalDate date;
+
+    @Builder.Default
+    private List<SchedulePlaceDetailResponseDto> schedulePlaces = new ArrayList<>();
+
+    public static ScheduleDetailResponseDto toDto(Schedule schedule, List<SchedulePlaceDetailResponseDto> schedulePlaces) {
+        return ScheduleDetailResponseDto.builder()
+                .scheduleId(schedule.getId())
+                .date(schedule.getVisitDate())
+                .schedulePlaces(schedulePlaces)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/domain/SchedulePlaceDetailResponseDto.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/domain/SchedulePlaceDetailResponseDto.java
@@ -1,0 +1,28 @@
+package com.triportreat.backend.plan.domain;
+
+import com.triportreat.backend.plan.entity.SchedulePlace;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class SchedulePlaceDetailResponseDto {
+    private Long schedulePlaceId;
+    private Long placeId;
+    private String memo;
+    private Integer visitOrder;
+    private Long expense;
+
+    public static SchedulePlaceDetailResponseDto toDto(SchedulePlace schedulePlace) {
+        return SchedulePlaceDetailResponseDto.builder()
+                .schedulePlaceId(schedulePlace.getId())
+                .placeId(schedulePlace.getPlace().getId())
+                .memo(schedulePlace.getMemo())
+                .visitOrder(schedulePlace.getVisitOrder())
+                .expense(schedulePlace.getExpense())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/error/exception/PlanNotFoundException.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/error/exception/PlanNotFoundException.java
@@ -1,0 +1,19 @@
+package com.triportreat.backend.plan.error.exception;
+
+import static com.triportreat.backend.common.response.FailMessage.PLAN_NOT_FOUND;
+
+import com.triportreat.backend.common.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class PlanNotFoundException extends AbstractException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return PLAN_NOT_FOUND.getMessage();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/service/PlanService.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/service/PlanService.java
@@ -1,7 +1,10 @@
 package com.triportreat.backend.plan.service;
 
 import com.triportreat.backend.plan.domain.PlanCreateRequestDto;
+import com.triportreat.backend.plan.domain.PlanDetailResponseDto;
 
 public interface PlanService {
     void createPlan(PlanCreateRequestDto planCreateRequestDto);
+
+    PlanDetailResponseDto getPlanDetail(Long id);
 }

--- a/backend/src/main/java/com/triportreat/backend/plan/service/impl/PlanServiceImpl.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/service/impl/PlanServiceImpl.java
@@ -3,12 +3,16 @@ package com.triportreat.backend.plan.service.impl;
 import com.triportreat.backend.place.entity.Place;
 import com.triportreat.backend.place.repository.PlaceRepository;
 import com.triportreat.backend.plan.domain.PlanCreateRequestDto;
+import com.triportreat.backend.plan.domain.PlanDetailResponseDto;
 import com.triportreat.backend.plan.domain.ScheduleCreateRequestDto;
+import com.triportreat.backend.plan.domain.ScheduleDetailResponseDto;
 import com.triportreat.backend.plan.domain.SchedulePlaceCreateRequestDto;
+import com.triportreat.backend.plan.domain.SchedulePlaceDetailResponseDto;
 import com.triportreat.backend.plan.entity.Plan;
 import com.triportreat.backend.plan.entity.Schedule;
 import com.triportreat.backend.plan.entity.SchedulePlace;
 import com.triportreat.backend.plan.error.exception.PlaceNotFoundException;
+import com.triportreat.backend.plan.error.exception.PlanNotFoundException;
 import com.triportreat.backend.plan.error.exception.UserNotFoundException;
 import com.triportreat.backend.plan.repository.PlanRepository;
 import com.triportreat.backend.plan.repository.SchedulePlaceRepository;
@@ -18,6 +22,7 @@ import com.triportreat.backend.user.entity.User;
 import com.triportreat.backend.user.repository.UserRepository;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -44,6 +49,13 @@ public class PlanServiceImpl implements PlanService {
         createSchedules(planCreateRequestDto.getSchedules(), plan);
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public PlanDetailResponseDto getPlanDetail(Long id) {
+        Plan plan = planRepository.findById(id).orElseThrow(PlanNotFoundException::new);
+        return PlanDetailResponseDto.toDto(plan, extractScheduleDetailsFromPlan(plan));
+    }
+
     private void createSchedules(List<ScheduleCreateRequestDto> schedulesRequests, Plan plan) {
         schedulesRequests.forEach(s -> {
             Schedule schedule = Schedule.toEntity(s, plan);
@@ -62,5 +74,17 @@ public class PlanServiceImpl implements PlanService {
 
     private String createPlanCode() {
         return UUID.randomUUID().toString().toUpperCase();
+    }
+
+    private List<ScheduleDetailResponseDto> extractScheduleDetailsFromPlan(Plan plan) {
+        return plan.getSchedules().stream()
+                .map(schedule -> ScheduleDetailResponseDto.toDto(schedule, extractSchedulePlaceDetailsFromSchedule(schedule)))
+                .collect(Collectors.toList());
+    }
+
+    private List<SchedulePlaceDetailResponseDto> extractSchedulePlaceDetailsFromSchedule(Schedule schedule) {
+        return schedule.getSchedulePlaces().stream()
+                .map(SchedulePlaceDetailResponseDto::toDto)
+                .collect(Collectors.toList());
     }
 }

--- a/backend/src/test/java/com/triportreat/backend/plan/controller/PlanControllerTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/controller/PlanControllerTest.java
@@ -1,23 +1,32 @@
 package com.triportreat.backend.plan.controller;
 
+import static com.triportreat.backend.common.response.FailMessage.PLAN_NOT_FOUND;
 import static com.triportreat.backend.common.response.FailMessage.VALIDATION_FAILED;
+import static com.triportreat.backend.common.response.SuccessMessage.GET_SUCCESS;
 import static com.triportreat.backend.common.response.SuccessMessage.POST_SUCCESS;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.triportreat.backend.plan.domain.PlanCreateRequestDto;
+import com.triportreat.backend.plan.domain.PlanDetailResponseDto;
 import com.triportreat.backend.plan.domain.ScheduleCreateRequestDto;
+import com.triportreat.backend.plan.domain.ScheduleDetailResponseDto;
 import com.triportreat.backend.plan.domain.SchedulePlaceCreateRequestDto;
+import com.triportreat.backend.plan.domain.SchedulePlaceDetailResponseDto;
+import com.triportreat.backend.plan.error.exception.PlanNotFoundException;
 import com.triportreat.backend.plan.service.PlanService;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -114,5 +123,69 @@ class PlanControllerTest {
                 .andExpect(jsonPath("$.status", equalTo(400)))
                 .andExpect(jsonPath("$.message", equalTo(VALIDATION_FAILED.getMessage())))
                 .andExpect(jsonPath("$.result", equalTo(false)));
+    }
+
+    @Nested
+    @DisplayName("계획 상세 조회")
+    class GetPlanDetail {
+
+        @Test
+        @DisplayName("성공")
+        void getPlanDetail_Success() throws Exception {
+            // given
+            PlanDetailResponseDto planDetail = createPlanDetailResponseDto();
+
+            // when
+            when(planService.getPlanDetail(anyLong())).thenReturn(planDetail);
+
+            // then
+            mockMvc.perform(get("/plans/{id}", 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.message").value(GET_SUCCESS.getMessage()))
+                    .andExpect(jsonPath("$.result").value(true))
+                    .andExpect(jsonPath("$.data.planId").value(1))
+                    .andExpect(jsonPath("$.data.schedules[0].scheduleId").value(1))
+                    .andExpect(jsonPath("$.data.schedules[1].scheduleId").value(2))
+                    .andExpect(jsonPath("$.data.schedules[0].schedulePlaces[0].schedulePlaceId").value(1))
+                    .andExpect(jsonPath("$.data.schedules[0].schedulePlaces[1].schedulePlaceId").value(2))
+                    .andExpect(jsonPath("$.data.schedules[1].schedulePlaces[0].schedulePlaceId").value(3))
+                    .andExpect(jsonPath("$.data.schedules[1].schedulePlaces[1].schedulePlaceId").value(4));
+
+        }
+
+        @Test
+        @DisplayName("실패 - 계획 정보 없음")
+        void getPlanDetail_PlanNotFound() throws Exception {
+            // given
+            // when
+            when(planService.getPlanDetail(anyLong())).thenThrow(PlanNotFoundException.class);
+
+            // then
+            mockMvc.perform(get("/plans/{id}", 1L))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(500))
+                    .andExpect(jsonPath("$.message").value(PLAN_NOT_FOUND.getMessage()))
+                    .andExpect(jsonPath("$.result").value(false))
+                    .andExpect(jsonPath("$.data").doesNotExist());
+        }
+
+        private PlanDetailResponseDto createPlanDetailResponseDto() {
+            List<SchedulePlaceDetailResponseDto> schedulePlaceDetails1 = List.of(
+                    SchedulePlaceDetailResponseDto.builder().schedulePlaceId(1L).build(),
+                    SchedulePlaceDetailResponseDto.builder().schedulePlaceId(2L).build());
+            List<SchedulePlaceDetailResponseDto> schedulePlaceDetails2 = List.of(
+                    SchedulePlaceDetailResponseDto.builder().schedulePlaceId(3L).build(),
+                    SchedulePlaceDetailResponseDto.builder().schedulePlaceId(4L).build());
+
+            List<ScheduleDetailResponseDto> scheduleDetail = List.of(
+                    ScheduleDetailResponseDto.builder().scheduleId(1L).schedulePlaces(schedulePlaceDetails1).build(),
+                    ScheduleDetailResponseDto.builder().scheduleId(2L).schedulePlaces(schedulePlaceDetails2).build());
+
+            return PlanDetailResponseDto.builder()
+                    .planId(1L)
+                    .schedules(scheduleDetail)
+                    .build();
+        }
     }
 }

--- a/backend/src/test/java/com/triportreat/backend/plan/domain/PlanDetailResponseDtoTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/domain/PlanDetailResponseDtoTest.java
@@ -1,0 +1,38 @@
+package com.triportreat.backend.plan.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.triportreat.backend.plan.entity.Plan;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PlanDetailResponseDtoTest {
+
+    @Test
+    @DisplayName("계획상세정보 Dto 변환")
+    void toDto() {
+        // given
+        Plan plan = Plan.builder()
+                .id(1L)
+                .title("title")
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(1))
+                .code("ABC")
+                .build();
+        List<ScheduleDetailResponseDto> schedules = List.of(
+                ScheduleDetailResponseDto.builder().scheduleId(1L).build(),
+                ScheduleDetailResponseDto.builder().scheduleId(2L).build());
+
+        // when
+        PlanDetailResponseDto planDetail = PlanDetailResponseDto.toDto(plan, schedules);
+
+        // then
+        assertThat(planDetail.getPlanId()).isEqualTo(1);
+        assertThat(planDetail.getStartDate()).isEqualTo(LocalDate.now());
+        assertThat(planDetail.getEndDate()).isEqualTo(LocalDate.now().plusDays(1));
+        assertThat(planDetail.getCode()).isEqualTo("ABC");
+        assertThat(planDetail.getSchedules().size()).isEqualTo(2);
+    }
+}

--- a/backend/src/test/java/com/triportreat/backend/plan/domain/ScheduleDetailResponseDtoTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/domain/ScheduleDetailResponseDtoTest.java
@@ -1,0 +1,32 @@
+package com.triportreat.backend.plan.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.triportreat.backend.plan.entity.Schedule;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ScheduleDetailResponseDtoTest {
+
+    @Test
+    void toDto() {
+        // given
+        Schedule schedule = Schedule.builder()
+                .id(1L)
+                .visitDate(LocalDate.now())
+                .build();
+        List<SchedulePlaceDetailResponseDto> schedulePlaceDetails = List.of(
+                SchedulePlaceDetailResponseDto.builder().schedulePlaceId(1L).build(),
+                SchedulePlaceDetailResponseDto.builder().schedulePlaceId(2L).build()
+        );
+
+        // when
+        ScheduleDetailResponseDto scheduleDetail = ScheduleDetailResponseDto.toDto(schedule, schedulePlaceDetails);
+
+        // then
+        assertThat(scheduleDetail.getScheduleId()).isEqualTo(1);
+        assertThat(scheduleDetail.getDate()).isEqualTo(LocalDate.now());
+        assertThat(scheduleDetail.getSchedulePlaces().size()).isEqualTo(2);
+    }
+}

--- a/backend/src/test/java/com/triportreat/backend/plan/domain/SchedulePlaceDetailResponseDtoTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/domain/SchedulePlaceDetailResponseDtoTest.java
@@ -1,0 +1,32 @@
+package com.triportreat.backend.plan.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.triportreat.backend.place.entity.Place;
+import com.triportreat.backend.plan.entity.SchedulePlace;
+import org.junit.jupiter.api.Test;
+
+class SchedulePlaceDetailResponseDtoTest {
+
+    @Test
+    void toDto() {
+        // given
+        SchedulePlace schedulePlace = SchedulePlace.builder()
+                .id(1L)
+                .place(Place.builder().id(1L).build())
+                .memo("memo")
+                .visitOrder(1)
+                .expense(10000L)
+                .build();
+
+        // when
+        SchedulePlaceDetailResponseDto schedulePlaceDetail = SchedulePlaceDetailResponseDto.toDto(schedulePlace);
+
+        // then
+        assertThat(schedulePlaceDetail.getSchedulePlaceId()).isEqualTo(1);
+        assertThat(schedulePlaceDetail.getPlaceId()).isEqualTo(1);
+        assertThat(schedulePlaceDetail.getMemo()).isEqualTo("memo");
+        assertThat(schedulePlaceDetail.getVisitOrder()).isEqualTo(1);
+        assertThat(schedulePlaceDetail.getExpense()).isEqualTo(10000);
+    }
+}

--- a/backend/src/test/java/com/triportreat/backend/plan/service/PlanServiceTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/service/PlanServiceTest.java
@@ -1,6 +1,7 @@
 package com.triportreat.backend.plan.service;
 
 import static com.triportreat.backend.common.response.FailMessage.PLACE_NOT_FOUND;
+import static com.triportreat.backend.common.response.FailMessage.PLAN_NOT_FOUND;
 import static com.triportreat.backend.common.response.FailMessage.USER_NOT_FOUND;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,12 +13,16 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 import com.triportreat.backend.place.entity.Place;
 import com.triportreat.backend.place.repository.PlaceRepository;
 import com.triportreat.backend.plan.domain.PlanCreateRequestDto;
+import com.triportreat.backend.plan.domain.PlanDetailResponseDto;
+import com.triportreat.backend.plan.domain.ScheduleDetailResponseDto;
 import com.triportreat.backend.plan.domain.SchedulePlaceCreateRequestDto;
 import com.triportreat.backend.plan.domain.ScheduleCreateRequestDto;
+import com.triportreat.backend.plan.domain.SchedulePlaceDetailResponseDto;
 import com.triportreat.backend.plan.entity.Plan;
 import com.triportreat.backend.plan.entity.Schedule;
 import com.triportreat.backend.plan.entity.SchedulePlace;
 import com.triportreat.backend.plan.error.exception.PlaceNotFoundException;
+import com.triportreat.backend.plan.error.exception.PlanNotFoundException;
 import com.triportreat.backend.plan.error.exception.UserNotFoundException;
 import com.triportreat.backend.plan.repository.PlanRepository;
 import com.triportreat.backend.plan.repository.SchedulePlaceRepository;
@@ -27,7 +32,9 @@ import com.triportreat.backend.user.repository.UserRepository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -131,5 +138,71 @@ class PlanServiceTest {
         assertThatThrownBy(() -> planService.createPlan(planCreateRequestDto))
                 .isInstanceOf(PlaceNotFoundException.class)
                 .hasMessage(PLACE_NOT_FOUND.getMessage());
+    }
+
+    @Nested
+    @DisplayName("계획 상세 조회")
+    class GetPlanDetail {
+
+        @Test
+        @DisplayName("성공")
+        void getPlanDetail_Success() {
+            // given
+            Plan plan = createPlan();
+            PlanDetailResponseDto expectedPlanDetail = createExpectedPlanDetail(plan);
+
+            // when
+            when(planRepository.findById(anyLong())).thenReturn(Optional.of(plan));
+            PlanDetailResponseDto planDetail = planService.getPlanDetail(1L);
+
+            // then
+            assertThat(planDetail.getSchedules().size()).isEqualTo(1);
+            assertThat(planDetail).usingRecursiveComparison().isEqualTo(expectedPlanDetail);
+        }
+
+        @Test
+        @DisplayName("실패 - 계획 데이터 없음")
+        void getPlanDetail_PlanNotFound() {
+            // given
+            Plan plan = createPlan();
+
+            // when
+            when(planRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            // then
+            assertThatThrownBy(() -> planService.getPlanDetail(plan.getId()))
+                    .isInstanceOf(PlanNotFoundException.class)
+                    .hasMessage(PLAN_NOT_FOUND.getMessage());
+        }
+
+        private Plan createPlan() {
+            SchedulePlace schedulePlace = SchedulePlace.builder()
+                    .id(1L)
+                    .place(Place.builder().id(1L).build())
+                    .build();
+
+            Schedule schedule = Schedule.builder()
+                    .id(1L)
+                    .schedulePlaces(List.of(schedulePlace))
+                    .build();
+
+            return Plan.builder()
+                    .id(1L)
+                    .schedules(List.of(schedule))
+                    .build();
+        }
+
+        private PlanDetailResponseDto createExpectedPlanDetail(Plan plan) {
+            List<SchedulePlaceDetailResponseDto> schedulePlaceDetails = plan.getSchedules().stream()
+                    .flatMap(schedule -> schedule.getSchedulePlaces().stream()
+                            .map(SchedulePlaceDetailResponseDto::toDto))
+                    .collect(Collectors.toList());
+
+            List<ScheduleDetailResponseDto> scheduleDetails = plan.getSchedules().stream()
+                    .map(schedule -> ScheduleDetailResponseDto.toDto(schedule, schedulePlaceDetails))
+                    .collect(Collectors.toList());
+
+            return PlanDetailResponseDto.toDto(plan, scheduleDetails);
+        }
     }
 }


### PR DESCRIPTION
## PR전 체크리스트
> 1. PR 및 Commit title을 형식에 맞게 작성했나요(e.g. TOT-123 : [TYPE]) O
> 2. Reviewers가 명확하게 지정됐나요? O
> 3. Assignees가 명확하게 지정됐나요? O


## 📝 작업 내용
- 계획 상세정보 조회 API 구현.
- `@Nested`로 서비스, 컨트롤러 테스트에서 기능 단위로 분리. (스크린샷 참고)
- 추후 지역정보조회, 계획저장 테스트 코드 리팩토링 예정.

### 스크린샷
<img width="256" alt="스크린샷 2024-03-09 오후 8 51 15" src="https://github.com/trip-or-treat/trip-or-treat/assets/93666531/6c1eb997-662b-4be2-ae77-e44a1910ed33">

## 💬 리뷰 요구사항


## 참고자료

