### PR TITLE
TOT-127 : [REFACTOR] 리뷰 저장 API 수정

### DIFF
--- a/backend/src/main/java/com/triportreat/backend/place/controller/ReviewController.java
+++ b/backend/src/main/java/com/triportreat/backend/place/controller/ReviewController.java
@@ -24,7 +24,7 @@ public class ReviewController {
         return ResponseEntity.ok().body(ResponseResult.success(GET_SUCCESS.getMessage(), reviewService.getReviewList(id, pageable)));
     }
 
-    @PostMapping("/places/review")
+    @PostMapping("/reviews")
     public ResponseEntity<?> postReview(@Valid @RequestBody ReviewRequestDto reviewRequestDto) {
         reviewRequestDto.setUserId(1L); // TODO 로그인 기능 구현 완료시 수정 필요
         reviewService.createReview(reviewRequestDto);

--- a/backend/src/test/java/com/triportreat/backend/place/controller/ReviewControllerTest.java
+++ b/backend/src/test/java/com/triportreat/backend/place/controller/ReviewControllerTest.java
@@ -124,7 +124,7 @@ public class ReviewControllerTest {
         @DisplayName("성공")
         void createReview() throws Exception {
 
-            mockMvc.perform(post("/places/review")
+            mockMvc.perform(post("/reviews")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(reviewRequestDto)))
                     .andExpect(status().isOk())
@@ -142,7 +142,7 @@ public class ReviewControllerTest {
             doThrow(new PlaceNotFoundException(reviewRequestDto.getPlaceId())).when(reviewService).createReview(reviewRequestDto);
 
             //when & then
-            mockMvc.perform(post("/places/review")
+            mockMvc.perform(post("/reviews")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(reviewRequestDto)))
                     .andExpect(status().isOk())
@@ -164,7 +164,7 @@ public class ReviewControllerTest {
                     .score(null)
                     .build();
             //when & then
-            mockMvc.perform(post("/places/review")
+            mockMvc.perform(post("/reviews")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(objectMapper.writeValueAsString(reviewRequestDto)))
                     .andExpect(status().isOk())

--- a/backend/src/test/java/com/triportreat/backend/place/controller/ReviewControllerTest.java
+++ b/backend/src/test/java/com/triportreat/backend/place/controller/ReviewControllerTest.java
@@ -171,7 +171,7 @@ public class ReviewControllerTest {
                     .andExpect(jsonPath("$.result").value(false))
                     .andExpect(jsonPath("$.message").value(VALIDATION_FAILED.getMessage()))
                     .andExpect(jsonPath("$.status").value(400))
-                    .andExpect(jsonPath("$.data.content").value("내용은 비워둘 수 없습니다."))
+                    .andExpect(jsonPath("$.data.content").value("내용은 필수 입력값입니다."))
                     .andExpect(jsonPath("$.data.score").value("별점은 필수 입력값입니다."));
         }
     }


### PR DESCRIPTION
## PR전 체크리스트
> 1. PR 및 Commit title을 형식에 맞게 작성했나요(e.g. TOT-123 : [TYPE])네
> 2. Reviewers가 명확하게 지정됐나요?네
> 3. Assignees가 명확하게 지정됐나요?네


## 📝 작업 내용
리뷰 저장 URL 경로 변경. '/places/review'에서 '/reviews'로 변경.
ReviewController 테스트 오류 수정

### 스크린샷


## 💬 리뷰 요구사항
- 리뷰 저장 API를 구현하면서 SuccessMessage 클래스의 POST_SUCCESS 메세지를 "계획 저장에 성공하였습니다."
에서 "저장에 성공하였습니다."로 바꾸었는데, 지난번 제 pr에서 해당 변경 사항을 못 보셨을 수도 있을 것 같아서 메세지 변경한 점 이곳에 한번 더 적어놓겠습니다!

## 참고자료

