### PR TITLE
TOT-130 : [REVERT] 필터 계층 응답 헤더에 cors 설정 추가

### DIFF
--- a/backend/src/main/java/com/triportreat/backend/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/triportreat/backend/auth/filter/JwtAuthenticationFilter.java
@@ -60,7 +60,6 @@ public class JwtAuthenticationFilter implements Filter {
         try {
             log.info("액세스 토큰 검증");
             String accessToken = jwtProvider.extractAccessToken(httpRequest);
-            log.info("액세스 토큰 정보 : {}", accessToken);
             if (jwtProvider.isValid(accessToken)) {
                 log.info("액세스 토큰 검증완료");
                 chain.doFilter(request, response);

--- a/backend/src/main/java/com/triportreat/backend/auth/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/triportreat/backend/auth/filter/JwtAuthenticationFilter.java
@@ -60,6 +60,7 @@ public class JwtAuthenticationFilter implements Filter {
         try {
             log.info("액세스 토큰 검증");
             String accessToken = jwtProvider.extractAccessToken(httpRequest);
+            log.info("액세스 토큰 정보 : {}", accessToken);
             if (jwtProvider.isValid(accessToken)) {
                 log.info("액세스 토큰 검증완료");
                 chain.doFilter(request, response);

--- a/backend/src/main/java/com/triportreat/backend/auth/filter/JwtExceptionFilter.java
+++ b/backend/src/main/java/com/triportreat/backend/auth/filter/JwtExceptionFilter.java
@@ -1,5 +1,6 @@
 package com.triportreat.backend.auth.filter;
 
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,6 +46,10 @@ public class JwtExceptionFilter implements Filter {
     public void jwtExceptionHandler(HttpServletResponse response, JwtException e) {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
+        response.setStatus(OK.value());
+        response.setHeader("Access-Control-Allow-Origin", "*");
+        response.setHeader("Access-Control-Allow-Methods", "POST, GET, PUT, OPTIONS, DELETE");
+        response.setHeader("Access-Control-Max-Age", "3600");
         try {
             ResponseResult result = ResponseResult.fail(e.getMessage(), UNAUTHORIZED, null);
             String jsonResponse = objectMapper.writeValueAsString(result);

--- a/backend/src/main/java/com/triportreat/backend/common/config/WebConfig.java
+++ b/backend/src/main/java/com/triportreat/backend/common/config/WebConfig.java
@@ -28,8 +28,8 @@ public class WebConfig implements WebMvcConfigurer {
                         "https://www.triportreat.site")
                 .allowedHeaders("*")
                 .exposedHeaders("Authorization")
-                .allowCredentials(true)
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowCredentials(true)
                 .maxAge(3600);
     }
 


### PR DESCRIPTION
- 필터에 의해 예외처리되는 응답은 애플리케이션 컨텍스트를 거치지 못하기 때문에 corsmapping 자체가 불가하므로 따로 예외처리 응답에 추가