### PR TITLE
TOT-130 : [REVERT] 필터 계층 응답 헤더 cors 설정 세분화

### DIFF
--- a/backend/src/main/java/com/triportreat/backend/auth/filter/JwtExceptionFilter.java
+++ b/backend/src/main/java/com/triportreat/backend/auth/filter/JwtExceptionFilter.java
@@ -1,5 +1,6 @@
 package com.triportreat.backend.auth.filter;
 
+import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,6 +46,21 @@ public class JwtExceptionFilter implements Filter {
     public void jwtExceptionHandler(HttpServletResponse response, JwtException e) {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
+        response.setStatus(OK.value());
+        response.setHeader("Access-Control-Allow-Origin",
+                "http://localhost:3000, "
+                        + "https://localhost:3000, "
+                        + "http://localhost:8080, "
+                        + "https://localhost:8080, "
+                        + "http://triportreat.site, "
+                        + "https://triportreat.site, "
+                        + "http://www.triportreat.site, "
+                        + "https://www.triportreat.site");
+        response.setHeader("Access-Control-Allow-Methods", "POST, GET, PUT, OPTIONS, DELETE");
+        response.setHeader("Access-Control-Allow-Headers", "*");
+        response.setHeader("Access-Control-Expose-Headers", "Authorization");
+        response.setHeader("Access-Control-Max-Age", "3600");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
         try {
             ResponseResult result = ResponseResult.fail(e.getMessage(), UNAUTHORIZED, null);
             String jsonResponse = objectMapper.writeValueAsString(result);

--- a/backend/src/main/java/com/triportreat/backend/auth/filter/JwtExceptionFilter.java
+++ b/backend/src/main/java/com/triportreat/backend/auth/filter/JwtExceptionFilter.java
@@ -1,6 +1,5 @@
 package com.triportreat.backend.auth.filter;
 
-import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -46,10 +45,6 @@ public class JwtExceptionFilter implements Filter {
     public void jwtExceptionHandler(HttpServletResponse response, JwtException e) {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
-        response.setStatus(OK.value());
-        response.setHeader("Access-Control-Allow-Origin", "*");
-        response.setHeader("Access-Control-Allow-Methods", "POST, GET, PUT, OPTIONS, DELETE");
-        response.setHeader("Access-Control-Max-Age", "3600");
         try {
             ResponseResult result = ResponseResult.fail(e.getMessage(), UNAUTHORIZED, null);
             String jsonResponse = objectMapper.writeValueAsString(result);

--- a/backend/src/main/java/com/triportreat/backend/common/config/WebConfig.java
+++ b/backend/src/main/java/com/triportreat/backend/common/config/WebConfig.java
@@ -28,8 +28,8 @@ public class WebConfig implements WebMvcConfigurer {
                         "https://www.triportreat.site")
                 .allowedHeaders("*")
                 .exposedHeaders("Authorization")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowCredentials(true)
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .maxAge(3600);
     }
 


### PR DESCRIPTION
- 요청시 credential 옵션을 사용하여 보내기 때문에 응답 origin 설정에 "*"를 사용할 수 없음
- 명확한 도메인 주소를 명시해야함