### PR TITLE
TOT-131 : [FEAT] 장소-스케줄 삭제 API 개발

### DIFF
--- a/backend/src/main/java/com/triportreat/backend/common/error/exception/AuthenticateFailException.java
+++ b/backend/src/main/java/com/triportreat/backend/common/error/exception/AuthenticateFailException.java
@@ -1,0 +1,19 @@
+package com.triportreat.backend.common.error.exception;
+
+import static com.triportreat.backend.common.response.FailMessage.AUTHENTICATION_FAILED;
+
+import com.triportreat.backend.common.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class AuthenticateFailException extends AbstractException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.UNAUTHORIZED;
+    }
+
+    @Override
+    public String getMessage() {
+        return AUTHENTICATION_FAILED.getMessage();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/common/error/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/triportreat/backend/common/error/handler/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.triportreat.backend.common.error.handler;
+
+import com.triportreat.backend.common.error.exception.AuthenticateFailException;
+import com.triportreat.backend.common.response.ResponseResult;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(AuthenticateFailException.class)
+    protected ResponseEntity<?> AuthenticateFailExceptionHandler(AuthenticateFailException e) {
+        return ResponseEntity.ok().body(ResponseResult.fail(e.getMessage(), e.getStatus(), null));
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/common/response/FailMessage.java
+++ b/backend/src/main/java/com/triportreat/backend/common/response/FailMessage.java
@@ -12,7 +12,8 @@ public enum FailMessage {
     USER_NOT_FOUND("사용자가 존재하지 않습니다!"),
     PLACE_NOT_FOUND("장소가 존재하지 않습니다!"),
     VALIDATION_FAILED("유효성 검증에 실패하였습니다!"),
-    PLAN_NOT_FOUND("계획이 존재하지 않습니다!");
+    PLAN_NOT_FOUND("계획이 존재하지 않습니다!"),
+    SCHEDULE_PLACE_NOT_FOUND("스케줄-장소가 존재하지 않습니다!");
 
     private final String message;
 

--- a/backend/src/main/java/com/triportreat/backend/common/response/FailMessage.java
+++ b/backend/src/main/java/com/triportreat/backend/common/response/FailMessage.java
@@ -13,6 +13,7 @@ public enum FailMessage {
     PLACE_NOT_FOUND("장소가 존재하지 않습니다!"),
     VALIDATION_FAILED("유효성 검증에 실패하였습니다!"),
     PLAN_NOT_FOUND("계획이 존재하지 않습니다!"),
+    AUTHENTICATION_FAILED("사용자 정보가 일치하지 않습니다!"),
     SCHEDULE_PLACE_NOT_FOUND("스케줄-장소가 존재하지 않습니다!");
 
     private final String message;

--- a/backend/src/main/java/com/triportreat/backend/common/response/SuccessMessage.java
+++ b/backend/src/main/java/com/triportreat/backend/common/response/SuccessMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum SuccessMessage {
         GET_SUCCESS("조회에 성공하였습니다."),
         POST_SUCCESS("저장에 성공하였습니다."),
-        LOGIN_SUCCESS("로그인에 성공하였습니다.");
+        LOGIN_SUCCESS("로그인에 성공하였습니다."),
+        DELETE_SUCCESS("삭제에 성공하였습니다.");
 
         private final String message;
 

--- a/backend/src/main/java/com/triportreat/backend/plan/controller/SchedulePlaceController.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/controller/SchedulePlaceController.java
@@ -1,0 +1,30 @@
+package com.triportreat.backend.plan.controller;
+
+import static com.triportreat.backend.common.response.SuccessMessage.DELETE_SUCCESS;
+
+import com.triportreat.backend.auth.utils.Auth;
+import com.triportreat.backend.common.response.ResponseResult;
+import com.triportreat.backend.plan.service.SchedulePlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/schedule-place")
+@RequiredArgsConstructor
+public class SchedulePlaceController {
+
+    private final SchedulePlaceService schedulePlaceService;
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteSchedulePlace(@Auth Long userId,
+                                                 @PathVariable("id") Long id) {
+        schedulePlaceService.validateSchedulePlaceOwner(userId, id);
+
+        schedulePlaceService.deleteSchedulePlace(id);
+        return ResponseEntity.ok().body(ResponseResult.success(DELETE_SUCCESS.getMessage(), null));
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/error/exception/SchedulePlaceNotFoundException.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/error/exception/SchedulePlaceNotFoundException.java
@@ -1,0 +1,19 @@
+package com.triportreat.backend.plan.error.exception;
+
+import static com.triportreat.backend.common.response.FailMessage.SCHEDULE_PLACE_NOT_FOUND;
+
+import com.triportreat.backend.common.AbstractException;
+import org.springframework.http.HttpStatus;
+
+public class SchedulePlaceNotFoundException extends AbstractException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public String getMessage() {
+        return SCHEDULE_PLACE_NOT_FOUND.getMessage();
+    }
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/repository/SchedulePlaceRepository.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/repository/SchedulePlaceRepository.java
@@ -1,8 +1,16 @@
 package com.triportreat.backend.plan.repository;
 
 import com.triportreat.backend.plan.entity.SchedulePlace;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SchedulePlaceRepository extends JpaRepository<SchedulePlace, Long> {
+
+    @Query("SELECT sp FROM SchedulePlace sp "
+            + "LEFT JOIN FETCH sp.schedule s "
+            + "LEFT JOIN FETCH s.plan p "
+            + "WHERE sp.id = :id AND p.user.id = :userId")
+    Optional<SchedulePlace> findByIdAndUserId(Long id, Long userId);
 
 }

--- a/backend/src/main/java/com/triportreat/backend/plan/service/SchedulePlaceService.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/service/SchedulePlaceService.java
@@ -1,0 +1,8 @@
+package com.triportreat.backend.plan.service;
+
+public interface SchedulePlaceService {
+
+    void validateSchedulePlaceOwner(Long userId, Long id);
+
+    void deleteSchedulePlace(Long id);
+}

--- a/backend/src/main/java/com/triportreat/backend/plan/service/impl/SchedulePlaceServiceImpl.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/service/impl/SchedulePlaceServiceImpl.java
@@ -1,5 +1,6 @@
 package com.triportreat.backend.plan.service.impl;
 
+import com.triportreat.backend.common.error.exception.AuthenticateFailException;
 import com.triportreat.backend.plan.error.exception.SchedulePlaceNotFoundException;
 import com.triportreat.backend.plan.repository.SchedulePlaceRepository;
 import com.triportreat.backend.plan.service.SchedulePlaceService;

--- a/backend/src/main/java/com/triportreat/backend/plan/service/impl/SchedulePlaceServiceImpl.java
+++ b/backend/src/main/java/com/triportreat/backend/plan/service/impl/SchedulePlaceServiceImpl.java
@@ -1,0 +1,29 @@
+package com.triportreat.backend.plan.service.impl;
+
+import com.triportreat.backend.plan.error.exception.SchedulePlaceNotFoundException;
+import com.triportreat.backend.plan.repository.SchedulePlaceRepository;
+import com.triportreat.backend.plan.service.SchedulePlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SchedulePlaceServiceImpl implements SchedulePlaceService {
+
+    private final SchedulePlaceRepository schedulePlaceRepository;
+
+    @Override
+    public void validateSchedulePlaceOwner(Long userId, Long id) {
+        schedulePlaceRepository.findById(id)
+                .orElseThrow(SchedulePlaceNotFoundException::new);
+        schedulePlaceRepository.findByIdAndUserId(id, userId)
+                .orElseThrow(AuthenticateFailException::new);
+    }
+
+    @Transactional
+    @Override
+    public void deleteSchedulePlace(Long id) {
+        schedulePlaceRepository.deleteById(id);
+    }
+}

--- a/backend/src/test/java/com/triportreat/backend/dummy/DummyObject.java
+++ b/backend/src/test/java/com/triportreat/backend/dummy/DummyObject.java
@@ -10,7 +10,6 @@ import com.triportreat.backend.plan.entity.Plan;
 import com.triportreat.backend.plan.entity.Schedule;
 import com.triportreat.backend.plan.entity.SchedulePlace;
 import com.triportreat.backend.user.entity.User;
-
 import java.time.LocalDate;
 import java.util.List;
 
@@ -34,6 +33,16 @@ public class DummyObject {
                 .build();
     }
 
+    protected Plan createMockPlan(User user) {
+        return Plan.builder()
+                .id(1L)
+                .title("Plan")
+                .user(user)
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusDays(1))
+                .build();
+    }
+
     protected Schedule createMockSchedule(Long id, LocalDate visitDate, List<SchedulePlace> schedulePlaces) {
         return Schedule.builder()
                 .id(id)
@@ -42,11 +51,28 @@ public class DummyObject {
                 .build();
     }
 
+    protected Schedule createMockSchedule(Plan plan) {
+        return Schedule.builder()
+                .id(1L)
+                .plan(plan)
+                .visitDate(LocalDate.now())
+                .build();
+    }
+
     protected SchedulePlace createMockSchedulePlace(Long id, Long placeId, int visitOrder) {
         return SchedulePlace.builder()
                 .id(id)
                 .place(Place.builder().id(placeId).build())
                 .visitOrder(visitOrder)
+                .memo("memo")
+                .expense(1000L)
+                .build();
+    }
+
+    protected SchedulePlace createMockSchedulePlace(Schedule schedule) {
+        return SchedulePlace.builder()
+                .schedule(schedule)
+                .visitOrder(1)
                 .memo("memo")
                 .expense(1000L)
                 .build();
@@ -95,6 +121,16 @@ public class DummyObject {
                 .content("testContent")
                 .tip("testTip")
                 .score(5)
+                .build();
+    }
+
+    protected Place createMockPlace(Long id) {
+        return Place.builder()
+                .id(id)
+                .name("place")
+                .latitude(1.0)
+                .longitude(1.0)
+                .views(0L)
                 .build();
     }
 }

--- a/backend/src/test/java/com/triportreat/backend/plan/controller/SchedulePlaceControllerTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/controller/SchedulePlaceControllerTest.java
@@ -1,0 +1,113 @@
+package com.triportreat.backend.plan.controller;
+
+import static com.triportreat.backend.common.response.FailMessage.AUTHENTICATION_FAILED;
+import static com.triportreat.backend.common.response.FailMessage.SCHEDULE_PLACE_NOT_FOUND;
+import static com.triportreat.backend.common.response.SuccessMessage.DELETE_SUCCESS;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.triportreat.backend.auth.filter.JwtAuthenticationFilter;
+import com.triportreat.backend.auth.filter.JwtExceptionFilter;
+import com.triportreat.backend.auth.utils.AuthUserArgumentResolver;
+import com.triportreat.backend.common.config.WebConfig;
+import com.triportreat.backend.common.error.exception.AuthenticateFailException;
+import com.triportreat.backend.plan.error.exception.SchedulePlaceNotFoundException;
+import com.triportreat.backend.plan.service.SchedulePlaceService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@AutoConfigureMockMvc
+@WebMvcTest(controllers = SchedulePlaceController.class,
+        excludeFilters = @ComponentScan.Filter(
+                type = FilterType.ASSIGNABLE_TYPE,
+                classes = {JwtExceptionFilter.class,
+                        JwtAuthenticationFilter.class,
+                        AuthUserArgumentResolver.class,
+                        WebConfig.class}))
+class SchedulePlaceControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SchedulePlaceService schedulePlaceService;
+
+    @Nested
+    @DisplayName("스케줄-장소 삭제")
+    class DeleteSchedulePlace {
+
+        @Test
+        @DisplayName("성공")
+        void deleteSchedulePlace() throws Exception {
+            // given
+            Long userId = 1L;
+            Long id = 1L;
+
+            doNothing().when(schedulePlaceService).deleteSchedulePlace(id);
+
+            // when
+            // then
+            mockMvc.perform(delete("/schedule-place/{id}", id))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.result").value(true))
+                    .andExpect(jsonPath("$.status").value(HttpStatus.OK.value()))
+                    .andExpect(jsonPath("$.message").value(DELETE_SUCCESS.getMessage()))
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @Test
+        @DisplayName("실패 - 인증 실패")
+        void deleteSchedulePlace_AuthenticateFail() throws Exception {
+            // given
+            Long userId = 1L;
+            Long id = 1L;
+
+
+            //validateSchedulePlaceOwner 메서드를 호출하는 케이스로 작성하면 테스트를 통과하지 못함
+            doThrow(AuthenticateFailException.class).when(schedulePlaceService).deleteSchedulePlace(id);
+
+            // when
+            // then
+            mockMvc.perform(delete("/schedule-place/{id}", id))
+                    .andExpect(status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.result").value(false))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.status").value(HttpStatus.UNAUTHORIZED.value()))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.message").value(AUTHENTICATION_FAILED.getMessage()))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data").isEmpty());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 스케줄-장소")
+        void deleteSchedulePlace_NotFoundSchedulePlace() throws Exception {
+            // given
+            Long userId = 1L;
+            Long id = 1L;
+
+            //validateSchedulePlaceOwner 메서드를 호출하는 케이스로 작성하면 테스트를 통과하지 못함
+            doThrow(SchedulePlaceNotFoundException.class).when(schedulePlaceService).deleteSchedulePlace(id);
+
+            // when
+            // then
+            mockMvc.perform(delete("/schedule-place/{id}", id))
+                    .andExpect(status().isOk())
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.result").value(false))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.status").value(HttpStatus.BAD_REQUEST.value()))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.message").value(SCHEDULE_PLACE_NOT_FOUND.getMessage()))
+                    .andExpect(MockMvcResultMatchers.jsonPath("$.data").isEmpty());
+        }
+    }
+
+}

--- a/backend/src/test/java/com/triportreat/backend/plan/repository/SchedulePlaceRepositoryTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/repository/SchedulePlaceRepositoryTest.java
@@ -1,0 +1,62 @@
+package com.triportreat.backend.plan.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.triportreat.backend.dummy.DummyObject;
+import com.triportreat.backend.place.repository.PlaceRepository;
+import com.triportreat.backend.plan.entity.Plan;
+import com.triportreat.backend.plan.entity.Schedule;
+import com.triportreat.backend.plan.entity.SchedulePlace;
+import com.triportreat.backend.user.entity.User;
+import com.triportreat.backend.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class SchedulePlaceRepositoryTest extends DummyObject {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    PlaceRepository placeRepository;
+
+    @Autowired
+    SchedulePlaceRepository schedulePlaceRepository;
+
+    @Autowired
+    ScheduleRepository scheduleRepository;
+
+    @Autowired
+    PlanRepository planRepository;
+
+    @Test
+    @DisplayName("스케줄-장소ID, 유저ID로 fetch join 테스트")
+    void findByIdAndUserId() {
+        // given
+        Long id = 1L;
+        User mockUser = createMockUser(id, "user");
+        userRepository.save(mockUser);
+
+        Plan mockPlan = createMockPlan(mockUser);
+        planRepository.save(mockPlan);
+
+        Schedule mockSchedule = createMockSchedule(mockPlan);
+        scheduleRepository.save(mockSchedule);
+
+        SchedulePlace mockSchedulePlace = createMockSchedulePlace(mockSchedule);
+        schedulePlaceRepository.save(mockSchedulePlace);
+
+        // when
+        Optional<SchedulePlace> findByFetchJoin = schedulePlaceRepository
+                .findByIdAndUserId(mockSchedulePlace.getId(), mockUser.getId());
+
+        // then
+        assertThat(findByFetchJoin).isNotEmpty();
+        assertThat(findByFetchJoin.get().getId()).isEqualTo(mockSchedulePlace.getId());
+        assertThat(findByFetchJoin.get().getSchedule().getPlan().getUser().getId()).isEqualTo(mockUser.getId());
+    }
+}

--- a/backend/src/test/java/com/triportreat/backend/plan/service/SchedulePlaceServiceTest.java
+++ b/backend/src/test/java/com/triportreat/backend/plan/service/SchedulePlaceServiceTest.java
@@ -1,0 +1,110 @@
+package com.triportreat.backend.plan.service;
+
+import static com.triportreat.backend.common.response.FailMessage.AUTHENTICATION_FAILED;
+import static com.triportreat.backend.common.response.FailMessage.SCHEDULE_PLACE_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.triportreat.backend.common.error.exception.AuthenticateFailException;
+import com.triportreat.backend.dummy.DummyObject;
+import com.triportreat.backend.plan.entity.SchedulePlace;
+import com.triportreat.backend.plan.error.exception.SchedulePlaceNotFoundException;
+import com.triportreat.backend.plan.repository.SchedulePlaceRepository;
+import com.triportreat.backend.plan.service.impl.SchedulePlaceServiceImpl;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SchedulePlaceServiceTest extends DummyObject {
+
+    @InjectMocks
+    SchedulePlaceServiceImpl schedulePlaceService;
+
+    @Mock
+    SchedulePlaceRepository schedulePlaceRepository;
+
+    @Nested
+    @DisplayName("스케줄-장소 소유자 검증")
+    class ValidateSchedulePlaceOwner {
+
+        @Test
+        @DisplayName("성공")
+        void validateSchedulePlaceOwner() {
+            // given
+            Long userId = 1L;
+            Long id = 1L;
+            SchedulePlace mockSchedulePlace = createMockSchedulePlace(1L, 123L, 1);
+
+            // when
+            when(schedulePlaceRepository.findById(id)).thenReturn(Optional.ofNullable(mockSchedulePlace));
+            when(schedulePlaceRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.ofNullable(mockSchedulePlace));
+
+            // then
+            assertDoesNotThrow(() -> schedulePlaceService.validateSchedulePlaceOwner(userId, id));
+        }
+
+        @Test
+        @DisplayName("실패 - 스케줄-장소가 존재하지 않으면 예외 발생")
+        void validateSchedulePlaceOwner_SchedulePlaceNotFound() {
+            // given
+            Long userId = 1L;
+            Long id = 1L;
+            SchedulePlace mockSchedulePlace = createMockSchedulePlace(10L, 123L, 1);
+
+            // when
+            when(schedulePlaceRepository.findById(id)).thenReturn(Optional.empty());
+
+            // then
+            assertThatThrownBy(() -> schedulePlaceService.validateSchedulePlaceOwner(userId, id))
+                    .isInstanceOf(SchedulePlaceNotFoundException.class)
+                    .hasMessageContaining(SCHEDULE_PLACE_NOT_FOUND.getMessage());
+
+        }
+
+        @Test
+        @DisplayName("실패 - 스케줄-장소 소유자가 아니면 예외 발생")
+        void validateSchedulePlaceOwner_AuthenticateFail() {
+            // given
+            Long userId = 2L;
+            Long id = 1L;
+            SchedulePlace mockSchedulePlace = createMockSchedulePlace(1L, 123L, 1);
+
+            // when
+            when(schedulePlaceRepository.findById(id)).thenReturn(Optional.ofNullable(mockSchedulePlace));
+            when(schedulePlaceRepository.findByIdAndUserId(id, userId)).thenReturn(Optional.empty());
+
+            // then
+            assertThatThrownBy(() -> schedulePlaceService.validateSchedulePlaceOwner(userId, id))
+                    .isInstanceOf(AuthenticateFailException.class)
+                    .hasMessageContaining(AUTHENTICATION_FAILED.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("스케줄-장소 삭제")
+    class DeleteSchedulePlace {
+
+        @Test
+        @DisplayName("성공")
+        void deleteSchedulePlace() {
+            // given
+            Long id = 1L;
+            SchedulePlace mockSchedulePlace = createMockSchedulePlace(1L, 123L, 1);
+
+            // when
+            schedulePlaceRepository.deleteById(id);
+
+            // then
+            verify(schedulePlaceRepository).deleteById(id);
+        }
+    }
+
+}


### PR DESCRIPTION
## PR전 체크리스트
> 1. PR 및 Commit title을 형식에 맞게 작성했나요(e.g. TOT-123 : [TYPE])
네
> 2. Reviewers가 명확하게 지정됐나요?
네
> 3. Assignees가 명확하게 지정됐나요?
네


## 📝 작업 내용
- 계획 수정과 별개로 스케줄에 포함된 장소는 별도의 삭제 API를 통해 삭제하도록 API 분리
- 데이터와 사용자 간 검증 로직 구현
- 스케줄-장소ID와 사용자ID를 기준으로 데이터를 조회하도록 Fetch Join 쿼리를 이용해 조회 메서드 구현

### 스크린샷


## 💬 리뷰 요구사항
- 컨트롤러 테스트 구현부에서 실패 케이스 작성 중 "validateSchedulePlaceOwner 메서드 실행 시 인증예외 발생"의 흐름으로 코드를 작성하면 테스트가 실패하는데 혹시 이게 정상인지, 아니라면 짐작가는 원인을 알고계시면 도움 부탁드립니다 ㅠ

## 참고자료

